### PR TITLE
docs: v2.0 Source Generator 化路线图与规范

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [2.0.0] - 规划中
+
+v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
+
+- 全面 Source Generator 化：消灭运行时反射、消灭 `Reflection.Emit`。
+- 移除 `Castle.Core` 依赖（~600 KB）。
+- NativeAOT publish 零警告。
+- `AddSkywalker()` 一行启动，零样板注册。
+
+设计与规划文档：
+
+- [`docs/architecture/v2.0-roadmap.md`](docs/architecture/v2.0-roadmap.md)
+- [`docs/architecture/source-generators-spec.md`](docs/architecture/source-generators-spec.md)
+- [`docs/architecture/source-generators-quality.md`](docs/architecture/source-generators-quality.md)
+
+发版策略：`main` → `2.0.0-alpha.x` → `2.0.0-preview.x` → `2.0.0-rc.x` → `2.0.0`。
+每个阶段最低浸泡 2 周，详见质量规范。
+
 ## [Unreleased]
 
 ### Removed

--- a/docs/architecture/source-generators-quality.md
+++ b/docs/architecture/source-generators-quality.md
@@ -1,0 +1,276 @@
+# Skywalker Source Generator 质量保证规范
+
+> 状态：**草案 (Draft)**　|　适用：v2.0+　|　最后更新：2026-04-21
+
+本规范定义 Skywalker 所有 SG 的质量基线和发版准入标准。
+设计规范见 [`source-generators-spec.md`](./source-generators-spec.md)。
+
+## 1. 八层质量保证体系
+
+### Layer 1: Snapshot Test（快照测试）—— 核心防线
+
+**工具**: [`Verify.SourceGenerators`](https://github.com/VerifyTests/Verify.SourceGenerators)
+
+**做法**: 每个生成场景都有一个 `.verified.cs` 文件入库。任何生成代码变化，CI 立即失败。
+
+```csharp
+[Fact]
+public Task AppService_WithGenericRepository_ShouldGenerate()
+{
+    var source = """
+        public partial class OrderAppService : IOrderAppService
+        {
+            public Task<Order> GetAsync(Guid id) => default!;
+        }
+        """;
+    return Verify(GeneratorTestHelper.Run<AppServiceGenerator>(source));
+}
+```
+
+**要求**：
+- 每个 SG ≥ 30 个 snapshot。
+- `.verified.cs` 必须 PR 中人工审查通过后才能入库。
+- 任何 `.received.cs` 出现在 CI = 失败。
+
+### Layer 2: Edge Case 测试矩阵
+
+**做法**: 在 `tests/SourceGenerators/EDGE_CASES.md` 维护"边界场景清单"，每加一个 case 打勾。
+
+强制覆盖的边界场景（节选）：
+
+```
+[ ] 普通 class
+[ ] partial class（多文件分布）
+[ ] record / record struct
+[ ] sealed / abstract class
+[ ] generic class（开放/闭合）
+[ ] nested class
+[ ] internal / public 可见性
+[ ] file-scoped class
+[ ] 全局命名空间（无 namespace）
+[ ] file-scoped namespace
+[ ] 多接口实现
+[ ] 接口继承链
+[ ] 跨程序集基类
+[ ] async / ValueTask / IAsyncEnumerable
+[ ] ref / in / out 参数
+[ ] ref struct 参数（应报警告）
+[ ] 显式接口实现
+[ ] static 方法
+[ ] default parameter values
+[ ] params 数组
+[ ] 泛型方法 T : new()
+[ ] attribute 转发
+[ ] global using 影响
+[ ] using alias
+```
+
+完整清单见 `tests/SourceGenerators/EDGE_CASES.md`。
+
+### Layer 3: Diagnostic 优先于沉默
+
+**铁律**: SG 遇到不支持的场景，**绝不能默默不生成**。必须报 `Diagnostic`。
+
+```csharp
+// ❌ 禁止
+if (!IsSupported(symbol)) return;
+
+// ✅ 必须
+if (!IsSupported(symbol))
+{
+    context.ReportDiagnostic(Diagnostic.Create(
+        SkyDiagnostics.RefLikeNotSupported,
+        symbol.Locations.FirstOrDefault(),
+        symbol.Name));
+    return;
+}
+```
+
+**理由**: 用户能接受功能不全，但接受不了"代码写得好好的，运行起来才发现没注册"。
+
+### Layer 4: Sample 项目矩阵 + 集成测试
+
+`samples/` 不是一个 demo，而是**故意造各种刁钻场景**的项目集：
+
+```
+samples/
+├── Skywalker.Sample.Minimal/           最简场景
+├── Skywalker.Sample.MultiDbContext/    多个 DbContext
+├── Skywalker.Sample.GenericServices/   泛型服务
+├── Skywalker.Sample.NestedTypes/       嵌套类型
+├── Skywalker.Sample.InternalServices/  internal 可见性
+├── Skywalker.Sample.Modular/           跨程序集模块
+├── Skywalker.Sample.AspireAOT/         NativeAOT publish 验证
+├── Skywalker.Sample.LegacyMigration/   v1 → v2 迁移场景
+└── Skywalker.Sample.RealWorldShop/     完整电商样例
+```
+
+**CI 必须执行**：
+1. 所有 sample `dotnet build` 成功
+2. 所有 sample 跑端到端集成测试
+3. AOT sample `dotnet publish -p:PublishAot=true` **零警告**
+4. 启动一次实际请求，验证生成代码真的工作
+
+### Layer 5: Downstream 项目验证
+
+CI 矩阵中纳入**真实 downstream 项目**编译验证：
+- Skywalker 自身的内部使用项目
+- Fork 的 ABP 改造样本
+- 种子用户的项目（征得同意后）
+
+每个 PR 在合并前必须 downstream 全绿。
+
+### Layer 6: Public API 锁定
+
+工具：[`Microsoft.CodeAnalysis.PublicApiAnalyzers`](https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md)
+
+```
+Skywalker.Xxx/
+├── PublicAPI.Shipped.txt    ← 已发布的 API 锁定
+└── PublicAPI.Unshipped.txt  ← 待发布的新增 API
+```
+
+任何破坏性 API 变更必须显式更新这两个文件，PR review 必看。
+
+### Layer 7: Beta / Preview 通道
+
+**绝不允许** main → 直接 stable。强制走：
+
+```
+main 提交              → -alpha 包到 GitHub Packages
+打 v2.0-preview tag    → -preview 包到 NuGet（≥ 2 周浸泡）
+打 v2.0-rc tag         → -rc 包（≥ 2 周浸泡）
+打 v2.0 tag            → stable 到 NuGet
+```
+
+每个阶段最少 2 周浸泡。早期 stable 用户用不到，但邀请 ≥ 3 个种子用户用 preview 反馈。
+
+### Layer 8: 专用 Issue 模板
+
+`.github/ISSUE_TEMPLATE/sg-bug.md` 强制要求用户提供：
+
+- 最小复现代码
+- 期望的生成代码
+- **实际生成的代码**（贴 `obj/Generated/` 中的 `.g.cs`）
+- Skywalker 版本、.NET 版本、IDE
+
+让维护者**秒定位问题**。
+
+## 2. 量化质量阈值
+
+### 2.1 单 SG 准入门槛（合并到 main）
+
+| 指标 | 阈值 |
+|---|---|
+| 单元测试覆盖率 | ≥ 85% |
+| Snapshot 测试场景 | ≥ 30 |
+| EDGE_CASES 相关项覆盖 | 100% |
+| 关联 sample 项目 | ≥ 1 |
+| 关联 SKYxxxx 诊断 | ≥ 5 |
+| 每个诊断有文档页 | ✅ |
+| AOT sample 零警告 | ✅ |
+| `PublicAPI.Unshipped.txt` 更新 | ✅ |
+
+### 2.2 Stable 发版准入清单
+
+打 `v2.0.0` 前必须满足全部：
+
+| 类别 | 指标 | 阈值 |
+|---|---|---|
+| **测试** | 全 SG 累计 snapshot 数 | ≥ 150 |
+| | 全 SG 累计 unit test 数 | ≥ 300 |
+| | 测试覆盖率 | ≥ 90% |
+| **样例** | sample 项目数 | ≥ 8 |
+| | 全部 sample CI 全绿 | ✅ |
+| | AOT publish 零警告 | ✅ |
+| **诊断** | 累计 SKYxxxx 数量 | ≥ 30 |
+| | 每个诊断有文档页 | 100% |
+| **API** | `PublicAPI.Shipped.txt` 完整 | ✅ |
+| **浸泡** | preview 浸泡时长 | ≥ 2 周 |
+| | rc 浸泡时长 | ≥ 2 周 |
+| | 已知 issue P0/P1 数 | 0 |
+| **文档** | 每个 attribute 有示例 | 100% |
+| | 迁移指南完整 | ✅ |
+| **种子用户** | 试用 preview 的项目数 | ≥ 3 |
+
+**任意一项不达标，禁止打 stable tag。**
+
+## 3. CI Pipeline 规范
+
+GitHub Actions 必备 workflow：
+
+```yaml
+jobs:
+  build:
+    # restore + build + unit test + snapshot test
+  
+  samples:
+    needs: build
+    strategy:
+      matrix:
+        sample: [Minimal, MultiDbContext, GenericServices, NestedTypes,
+                 InternalServices, Modular, LegacyMigration, RealWorldShop]
+    # 每个 sample build + integration test
+  
+  aot-publish:
+    needs: build
+    # AspireAOT sample 跑 dotnet publish -p:PublishAot=true
+    # 任何 IL2xxx / IL3xxx 警告 = 失败
+  
+  public-api-check:
+    # 跑 PublicApiAnalyzers，确保 Shipped.txt + Unshipped.txt 一致
+  
+  pack-alpha:
+    if: github.ref == 'refs/heads/main' && success()
+    # 发 -alpha 包到 GitHub Packages
+```
+
+## 4. 质量承诺（对外）
+
+Skywalker v2.0 stable 发布时承诺：
+
+> **80%** 的常见场景，第一次就能跑。
+>
+> **18%** 的边缘场景，编译错误明确指出问题，用户改一下就 OK。
+>
+> **2%** 的真·未知场景，报 issue → **1 周内 patch 版本**修复。
+
+**不承诺"已经覆盖所有场景"，承诺"遇到不支持的场景给你明确的编译错误"。**
+
+## 5. 流程规范
+
+### 5.1 新增 SG 流程
+
+1. 在 v2.0 Epic Issue 下开子 issue，描述目标
+2. Sprint 0 基础设施先就位（一次性）
+3. 创建分支 `feat/sg-<功能>`
+4. 实现 generator + 测试 + sample
+5. PR 时勾选 §9 检查清单
+6. Review + downstream 验证
+7. 合并 → 自动发 -alpha
+8. 收集 1-2 周种子用户反馈
+9. 进入下一个 Sprint
+
+### 5.2 Bug 响应 SLA
+
+| 严重级 | 响应 | 修复 |
+|---|---|---|
+| P0（生成代码导致编译失败 / 运行炸） | 24h | 1 周内 patch |
+| P1（功能性缺失，无 workaround） | 3 天 | 2 周内 patch |
+| P2（功能性缺失，有 workaround） | 1 周 | 下个 minor |
+| P3（优化建议、文档问题） | 2 周 | 视情况 |
+
+### 5.3 浸泡期违规处理
+
+如果出现以下情况，**重置浸泡计时**：
+
+- preview/rc 期间发现 P0 → 修复后浸泡时间从 0 重新计算
+- preview/rc 期间合并大型功能改动 → 浸泡时间从 0 重新计算
+
+## 6. 维护者纪律
+
+- **永远不要承诺**"已经覆盖所有场景"。
+- **永远不要**为了赶版本跳过浸泡期。
+- **永远不要**接受没有 snapshot 测试的 SG PR。
+- **永远不要**默默 `return` 不报诊断。
+- **永远不要**让 `MakeGenericType` / `Reflection.Emit` 出现在 v2.0 热路径。

--- a/docs/architecture/source-generators-spec.md
+++ b/docs/architecture/source-generators-spec.md
@@ -1,0 +1,378 @@
+# Skywalker Source Generator 设计规范
+
+> 状态：**草案 (Draft)**　|　适用：v2.0+　|　最后更新：2026-04-21
+
+本规范是 Skywalker 内部所有 Source Generator 的统一设计准则。
+任何新增 SG 必须遵守。质量保证细则见 [`source-generators-quality.md`](./source-generators-quality.md)。
+
+## 1. 总则
+
+### 1.1 设计原则
+
+1. **零运行时开销**：所有可在编译期完成的工作绝不延迟到运行时。
+2. **零用户配置**：用户引用包即生效，不要求修改 csproj 或调用初始化方法。
+3. **诊断优先于沉默**：遇到不支持的场景必须报 `Diagnostic`，绝不静默跳过。
+4. **生成代码即文档**：生成的 `.g.cs` 必须可读、可 F12 跳转、可调试。
+5. **增量优先**：必须使用 `IIncrementalGenerator`，禁止使用过时的 `ISourceGenerator`。
+
+### 1.2 命名约定
+
+| 项目 | 命名 | 示例 |
+|---|---|---|
+| Generator 项目 | `<宿主项目>.SourceGenerators` | `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` |
+| Generator 类 | `<功能>Generator` | `RepositoryRegistrationGenerator` |
+| 生成文件 | `<语义名>.g.cs` | `ShopDbContext.Repositories.g.cs` |
+| 生成命名空间 | 跟随源类型；模块入口固定 `Skywalker.Generated` | - |
+| 标注属性 | `<语义名>Attribute` | `ApplicationServiceAttribute` |
+| 诊断码 | `SKY####` 四位数字 | `SKY1001` |
+
+### 1.3 诊断码段位
+
+| 段位 | 用途 |
+|---|---|
+| `SKY1xxx` | DI / 服务注册相关 |
+| `SKY2xxx` | DynamicProxy / 拦截器相关 |
+| `SKY3xxx` | EF Repository 相关 |
+| `SKY4xxx` | EventBus 相关 |
+| `SKY5xxx` | Permission / Localization / Settings 相关 |
+| `SKY9xxx` | 通用（必须 partial、必须 public 等） |
+
+## 2. 项目结构规范
+
+### 2.1 Generator 项目 csproj 模板
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)"
+                      PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(RoslynAnalyzersVersion)"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- 把 generator dll 打到 analyzers 目录，使用者无需额外配置 -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+  </ItemGroup>
+
+</Project>
+```
+
+**关键点**：
+- `TargetFramework` **必须** `netstandard2.0`（Roslyn 限制）。
+- `IncludeBuildOutput=false` + `Pack="true" PackagePath="analyzers/dotnet/cs"`：
+  这样 generator dll 会随宿主 NuGet 包一起发布，使用者引宿主包即生效。
+
+### 2.2 宿主项目引用
+
+宿主项目（如 `Skywalker.Ddd.EntityFrameworkCore`）这样引：
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="..\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false"
+                    PrivateAssets="all" />
+</ItemGroup>
+```
+
+### 2.3 测试项目
+
+每个 generator 配套一个 `.Tests` 项目，结构：
+
+```
+Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.Tests/
+├── Snapshots/                    ← Verify 快照存放
+│   └── *.verified.cs
+├── EdgeCases/                    ← 边界场景测试
+├── Diagnostics/                  ← 诊断码测试
+├── GeneratorTestHelper.cs
+└── *.cs
+```
+
+## 3. 代码组织规范
+
+### 3.1 Generator 实现骨架
+
+```csharp
+[Generator(LanguageNames.CSharp)]
+public sealed class XxxGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // 1. 提供常量源（attribute 定义等）
+        context.RegisterPostInitializationOutput(PostInitialize);
+
+        // 2. 收集目标语法
+        var targets = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                fullyQualifiedMetadataName: "Skywalker.Xxx.XxxAttribute",
+                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                transform: static (ctx, ct) => Transform(ctx, ct))
+            .Where(static x => x is not null);
+
+        // 3. 输出
+        context.RegisterSourceOutput(targets, Generate);
+    }
+
+    private static void PostInitialize(IncrementalGeneratorPostInitializationContext ctx) { /* ... */ }
+    private static XxxModel? Transform(GeneratorAttributeSyntaxContext ctx, CancellationToken ct) { /* ... */ }
+    private static void Generate(SourceProductionContext ctx, XxxModel model) { /* ... */ }
+}
+```
+
+**强制要求**：
+- `predicate` / `transform` 委托必须 `static`。
+- 中间数据模型（如 `XxxModel`）必须为 `record` 或实现值相等，**禁止持有 `ISymbol` / `SyntaxNode`**（破坏增量缓存）。
+- 必须使用 `ForAttributeWithMetadataName` API（Roslyn 4.4+），不得自己写 `CreateSyntaxProvider` 扫全树。
+
+### 3.2 数据模型规范
+
+```csharp
+// ✅ 正确：值相等的 record，只持有原始数据
+internal sealed record AppServiceModel(
+    string Namespace,
+    string ClassName,
+    string InterfaceName,
+    EquatableArray<MethodModel> Methods);
+
+// ❌ 错误：持有 Symbol，破坏增量
+internal sealed record AppServiceModel(INamedTypeSymbol Symbol);
+```
+
+集合必须用 `EquatableArray<T>`（自定义结构，封装 `ImmutableArray<T>` + 值相等），
+不能直接用 `ImmutableArray<T>` / `IReadOnlyList<T>`。
+
+### 3.3 代码生成规范
+
+#### 必须使用 raw string literal，禁止 `StringBuilder` 拼接：
+
+```csharp
+// ✅ 正确
+var source = $$"""
+    // <auto-generated />
+    #nullable enable
+    namespace {{model.Namespace}};
+
+    partial class {{model.ClassName}}
+    {
+        // ...
+    }
+    """;
+
+// ❌ 错误
+var sb = new StringBuilder();
+sb.AppendLine("// <auto-generated />");
+sb.Append("namespace ").Append(model.Namespace).AppendLine(";");
+```
+
+#### 生成文件必须包含的头部：
+
+```csharp
+// <auto-generated/>
+// This file was generated by Skywalker Source Generators.
+// Do not modify this file manually.
+
+#nullable enable
+#pragma warning disable
+```
+
+#### 生成文件必须以 `.g.cs` 结尾：
+
+```csharp
+ctx.AddSource($"{model.ClassName}.Repositories.g.cs", source);
+```
+
+## 4. 用户 API 规范
+
+### 4.1 标注属性约定
+
+所有用户面向标注必须满足：
+
+- 放在 `Skywalker.<功能>` 命名空间。
+- 提供无参构造函数（最常用场景零配置）。
+- 所有可选项作为命名属性。
+- 提供 `[AttributeUsage]` 严格限定。
+
+```csharp
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class ApplicationServiceAttribute : Attribute
+{
+    public ServiceLifetime Lifetime { get; init; } = ServiceLifetime.Scoped;
+    public Type? ServiceType { get; init; }
+}
+```
+
+### 4.2 约定优于配置
+
+每个标注必须支持"命名约定 fallback"：
+
+| 标注 | 命名约定 fallback |
+|---|---|
+| `[ApplicationService]` | 类名以 `AppService` 结尾 |
+| `[Repository]` | 继承 `Repository<,,>` |
+| `[EventHandler]` | 实现 `ILocalEventHandler<>` |
+
+约定可被 csproj 关闭：
+
+```xml
+<PropertyGroup>
+  <SkywalkerConventionAutoRegister>false</SkywalkerConventionAutoRegister>
+</PropertyGroup>
+```
+
+通过 `<CompilerVisibleProperty>` 暴露给 SG。
+
+### 4.3 模块入口生成
+
+每个含 SG 标注的程序集，自动生成：
+
+```csharp
+// Skywalker.Generated/__SkywalkerModuleInitializer__.g.cs
+namespace Skywalker.Generated;
+
+internal static class __SkywalkerModuleInitializer__
+{
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        SkywalkerModuleRegistry.Register(typeof(__SkywalkerModuleInitializer__).Assembly,
+            services =>
+            {
+                // SG 生成的所有注册调用
+                services.AddOrdersDbContextRepositories();
+                services.AddApplicationServices();
+                services.AddEventHandlers();
+            });
+    }
+}
+```
+
+`AddSkywalker()` 在运行时遍历 `SkywalkerModuleRegistry` 即可，**无任何反射**。
+
+## 5. 诊断 (Diagnostics) 规范
+
+### 5.1 强制要求
+
+所有"不能正确生成代码"的情况必须报诊断，**禁止静默跳过**。
+
+```csharp
+private static readonly DiagnosticDescriptor MustBePartial = new(
+    id: "SKY9001",
+    title: "Service class must be partial",
+    messageFormat: "Class '{0}' marked with [{1}] must be declared as partial",
+    category: "Skywalker.SourceGenerators",
+    defaultSeverity: DiagnosticSeverity.Error,
+    isEnabledByDefault: true,
+    description: "Skywalker source generators emit additional members into your class. The class must be 'partial'.",
+    helpLinkUri: "https://skywalker.dev/diagnostics/SKY9001");
+```
+
+### 5.2 诊断质量要求
+
+每个 `SKYxxxx` 必须满足：
+
+- `helpLinkUri` 指向真实文档页（`docs/diagnostics/SKYxxxx.md`）。
+- `messageFormat` 包含足够上下文（类型名、属性名、原因）。
+- `description` 说明正确做法。
+- 测试项目里有对应的 `*_ShouldReportDiagnostic` 测试。
+
+### 5.3 文档页模板
+
+每个 `docs/diagnostics/SKYxxxx.md`：
+
+```markdown
+# SKY9001: Service class must be partial
+
+| 项 | 值 |
+|---|---|
+| 严重性 | Error |
+| 引入版本 | 2.0.0 |
+
+## 原因
+
+...
+
+## 错误示例
+
+...
+
+## 正确示例
+
+...
+
+## 相关链接
+
+...
+```
+
+## 6. 增量与性能规范
+
+- **必须使用** `ForAttributeWithMetadataName`（避免扫全树）。
+- 数据模型必须值相等（用 record + EquatableArray）。
+- `transform` 内不得调用 `Compilation.GetSemanticModel` 之外的耗时操作。
+- 每个 generator 必须有 `IsCacheable` 测试（连续两次运行缓存命中率 100%）。
+
+## 7. 兼容性规范
+
+### 7.1 Roslyn 版本
+
+- 最低支持：Roslyn 4.4 (`Microsoft.Net.Sdk` 8.0+)。
+- 推荐：Roslyn 4.8+。
+- 在宿主 csproj 设置 `<LangVersion>latest</LangVersion>`，但生成代码必须兼容 C# 10+。
+
+### 7.2 C# 语言特性使用
+
+生成代码可使用：
+- ✅ file-scoped namespace
+- ✅ raw string literal
+- ✅ pattern matching
+- ✅ `required` / `init`
+
+生成代码**不应使用**（兼容性考量）：
+- ❌ `extension` （C# 14 预览）
+- ❌ primary constructor on class（兼容旧 IDE）
+
+## 8. 公共 API 锁定
+
+每个发包项目必须接入 `Microsoft.CodeAnalysis.PublicApiAnalyzers`：
+
+```
+Skywalker.Xxx/
+├── PublicAPI.Shipped.txt
+└── PublicAPI.Unshipped.txt
+```
+
+任何破坏性 API 变更必须显式更新这两个文件，PR review 必看。
+
+## 9. 检查清单
+
+新增 SG 时必须确认（PR 模板将包含此清单）：
+
+- [ ] Generator 项目 csproj 符合 §2.1 模板
+- [ ] 使用 `IIncrementalGenerator` + `ForAttributeWithMetadataName`
+- [ ] 数据模型为 record + EquatableArray
+- [ ] 生成代码使用 raw string literal
+- [ ] 生成文件 `.g.cs` 后缀 + auto-generated 头部
+- [ ] 用户标注满足 §4.1 约定
+- [ ] 提供命名约定 fallback
+- [ ] 所有"不能生成"场景报 `SKYxxxx` 诊断
+- [ ] 每个诊断有 `docs/diagnostics/` 文档页
+- [ ] Snapshot 测试覆盖 §EDGE_CASES.md 相关场景
+- [ ] 至少 1 个 sample 项目使用该 generator
+- [ ] AOT publish 零警告
+- [ ] `PublicAPI.Unshipped.txt` 更新

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -1,0 +1,170 @@
+# Skywalker v2.0 路线图
+
+> 状态：**草案 (Draft)**　|　目标版本：**v2.0.0**　|　最后更新：2026-04-21
+
+## 1. 定位 (Positioning)
+
+Skywalker v2.0 的差异化关键词：**小、快、易用**。
+
+- **小**：移除 Castle.Core (~600 KB) 等重量级运行时依赖。
+- **快**：消灭启动期反射；消灭运行时 IL Emit；NativeAOT 一等公民。
+- **易用**：`AddSkywalker()` 一行启动；零样板注册；约定优于配置。
+
+对标的不是 ABP，而是 [Mapperly](https://github.com/riok/mapperly) 之于 AutoMapper、
+[FastEndpoints](https://fast-endpoints.com/) 之于 MVC——**用 Source Generator 把现代 .NET 的能力发挥到极致**。
+
+Slogan:
+
+> *Define your service. We do the rest. — Zero reflection, zero registration, zero runtime cost.*
+
+## 2. 核心战略
+
+**所有运行时反射、动态类型构造、IL Emit 全部迁移到 Source Generator。**
+
+详见 [`source-generators-spec.md`](./source-generators-spec.md)。
+
+## 3. 范围
+
+### 3.1 In Scope（v2.0 必做）
+
+| # | 项目 | 现状 | v2.0 目标 |
+|---|---|---|---|
+| 1 | EF Repository 注册 | 反射 `MakeGenericType` | SG 编译期生成 |
+| 2 | DynamicProxy 拦截器 | Castle.DynamicProxy IL Emit | SG 编译期生成静态代理 |
+| 3 | DI 服务注册 | 部分手动 | `[Service]` / `[ApplicationService]` 标注 + SG |
+| 4 | EventBus Handler 发现 | 反射扫程序集 | SG 编译期收集 |
+| 5 | 移除 Castle.Core 依赖 | 强依赖 | 完全移除 |
+| 6 | NativeAOT publish 零警告 | ❌ | ✅ |
+| 7 | `AddSkywalker()` 统一入口 | 多个 `AddXxx()` | 一行启动 |
+
+### 3.2 Stretch Goal（v2.0 力争）
+
+| # | 项目 | 价值 |
+|---|---|---|
+| 8 | Permission 强类型 SG | 编译期生成权限常量类 |
+| 9 | Localization Key 强类型 SG | 编译期生成强类型 Key 访问器 |
+| 10 | Settings 强类型 SG | 编译期生成强类型 Settings 访问器 |
+| 11 | Roslyn Code Fix 迁移工具 | 一键迁移 v1.x → v2.0 |
+
+### 3.3 Out of Scope（v2.0 不做）
+
+- 多租户系统的全面重写（保持 v1.x 现状）
+- 审计日志、后台任务模块（v2.x 后续）
+- ABP Commercial 等同的高级模块
+
+## 4. 阶段划分
+
+### Sprint 0（基础设施）—— 1 周
+
+发版前的"质量地基"。**绝不直接开始写 SG**，先把以下到位：
+
+- [ ] `tests/Skywalker.SourceGenerators.Tests/` 测试项目
+- [ ] 引入 `Verify.SourceGenerators` + `Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing`
+- [ ] `GeneratorTestHelper`（封装 driver 创建、引用集合、输出收集）
+- [ ] `tests/SourceGenerators/EDGE_CASES.md` 边界场景清单
+- [ ] `Microsoft.CodeAnalysis.PublicApiAnalyzers` 接入
+- [ ] CI workflow：build → unit test → snapshot → samples → AOT publish 全链路
+- [ ] `samples/` 矩阵骨架（8 个项目）
+- [ ] `docs/diagnostics/` 诊断码索引页骨架
+
+输出物：可以直接套用的 SG 开发流程。
+
+### Sprint 1（EF Repository SG）—— 2 周
+
+最小可行 SG，验证整套流程。
+
+- [ ] `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目
+- [ ] 替换 `AddDefaultServices<TDbContext>` 反射逻辑
+- [ ] ≥ 30 个 snapshot 测试
+- [ ] ≥ 5 个相关 sample 项目
+- [ ] ≥ 5 个 SKYxxxx diagnostic + 文档页
+- [ ] 发 `2.0.0-alpha.1`，邀请 ≥ 3 个种子用户试用
+- [ ] 浸泡 ≥ 2 周无 P0/P1，进入 preview
+
+里程碑：**EF 模块零反射**。
+
+### Sprint 2（DynamicProxy SG + 移除 Castle）—— 3 周
+
+v2.0 核心战役。
+
+- [ ] `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目
+- [ ] 编译期生成静态代理类
+- [ ] 移除 `Castle.Core` 依赖
+- [ ] `[Intercept<T>]` 强类型拦截器 API
+- [ ] ≥ 50 个 snapshot 测试（覆盖 async/泛型/ref/out 等边界）
+- [ ] AOT sample 验证零警告
+
+里程碑：**项目零 IL Emit、零 Castle 依赖**。
+
+### Sprint 3（DI 自动注册 SG）—— 1 周
+
+- [ ] `[Service]` / `[ApplicationService]` / `[Repository]` / `[EventHandler]` 标注
+- [ ] 模块入口 SG 生成 `__SkywalkerModuleInitializer__`
+- [ ] `AddSkywalker()` 统一入口
+- [ ] 命名约定 fallback（`*AppService` 等）
+
+里程碑：**Program.cs 缩减到 2 行**。
+
+### Sprint 4（Stretch Goals）—— 视情况 1-3 周
+
+按优先级挑做：Permission / Localization / Settings 强类型 SG。
+
+### Sprint 5（发版）—— 4 周
+
+- [ ] 全部 sample 全绿
+- [ ] AOT publish 零警告
+- [ ] Public API 锁定（`PublicAPI.Shipped.txt`）
+- [ ] 文档完整：每个 attribute 有示例，每个 SKYxxxx 有诊断页
+- [ ] `2.0.0-preview.1` → 浸泡 ≥ 2 周
+- [ ] `2.0.0-rc.1` → 浸泡 ≥ 2 周
+- [ ] `2.0.0` 正式发布
+- [ ] v1.x → v2.0 迁移指南
+
+## 5. 发版通道
+
+```
+main 提交              → 自动发 -alpha 包到 GitHub Packages
+打 v2.0-preview tag    → 发 -preview 包到 NuGet（≥ 2 周浸泡）
+打 v2.0-rc tag         → 发 -rc 包（≥ 2 周浸泡）
+打 v2.0 tag            → 发 stable 到 NuGet
+```
+
+**严禁** main → 直接 stable。每个阶段最低浸泡 2 周。
+
+## 6. Stable 发版准入清单
+
+详见 [`source-generators-quality.md`](./source-generators-quality.md#stable-发版准入清单)。
+
+## 7. Breaking Changes 提要
+
+v1.x → v2.0 的破坏性变更：
+
+| # | 变更 | 影响 | 迁移方案 |
+|---|---|---|---|
+| 1 | 移除 `Castle.Core` | 直接使用 Castle API 的代码 | 用 `[Intercept<T>]` |
+| 2 | `IInterceptable` 标注 → SG 标注 | 实现该接口的服务 | 加 `partial`，标 `[ApplicationService]` |
+| 3 | `AddInterceptedServices()` 删除 | Program.cs | 改用 `AddSkywalker()` |
+| 4 | AppService 无需继承基类 | （无强制破坏，向后兼容） | 可选迁移 |
+| 5 | EF Repository 注册改为 SG | （API 不变，行为等价） | 透明 |
+| 6 | 服务类型必须 `partial` | 标注的服务 | 加 `partial` 关键字 |
+
+完整迁移指南随 v2.0 stable 发布。
+
+## 8. 风险登记
+
+| 风险 | 概率 | 影响 | 缓解 |
+|---|---|---|---|
+| SG 边界场景遗漏导致用户翻车 | 高 | 高 | 严格执行质量标准 + diagnostic 优先于沉默 |
+| 学习曲线陡，作者侧效率低 | 中 | 中 | 建立 SG helper 基类 + raw string literal + 模板 |
+| 浸泡期种子用户不足 | 中 | 中 | 主动社区邀请；自有项目作为种子 1 |
+| Castle 老用户拒绝迁移 | 低 | 中 | v2.0 提供 1 个 minor 的 `[Obsolete]` 兼容层 |
+| 跨程序集 SG 信息丢失 | 中 | 高 | 模块入口生成 `[ModuleInitializer]` 自动挂载 |
+
+## 9. 决策记录
+
+| 日期 | 决策 | 备注 |
+|---|---|---|
+| 2026-04-21 | 选定 SG 路线 | 否决 DispatchProxy / Fody / 反射优化等替代方案 |
+| 2026-04-21 | 不再"抄 ABP"，定位"小快易用" | 差异化战略 |
+| 2026-04-21 | Sprint 0 必须先于 Sprint 1 | 质量基础设施优先 |
+| 2026-04-21 | 发版强制走 alpha → preview → rc → stable | 浸泡 ≥ 2 周/阶段 |


### PR DESCRIPTION
## 概述

为 Skywalker v2.0 落地三份规划文档，目的是把"全面 Source Generator 化"这一战略路线**写成可执行的规范**，避免开工后摇摆和返工。

关联 Epic：#182

## 变更内容

### 新增

- `docs/architecture/v2.0-roadmap.md` — v2.0 路线图
  - 定位（小、快、易用）、范围（in/stretch/out scope）
  - 6 个 Sprint 的目标与里程碑
  - 发版通道、Breaking Changes、风险登记、决策记录
- `docs/architecture/source-generators-spec.md` — SG 设计规范
  - 项目结构与 csproj 模板（含 `analyzers/dotnet/cs` 打包）
  - 命名约定、诊断码段位
  - `IIncrementalGenerator` + `ForAttributeWithMetadataName` 强制要求
  - 数据模型值相等、raw string literal、auto-generated 头部
  - 用户 API 约定、模块入口生成（`__SkywalkerModuleInitializer__`）
  - 增量与性能、兼容性、Public API 锁定、检查清单
- `docs/architecture/source-generators-quality.md` — SG 质量规范
  - **八层质量保证体系**（snapshot、edge case、diagnostic、samples、downstream、PublicApi、preview/rc 通道、issue 模板）
  - **量化阈值**（单 SG 准入门槛、stable 发版准入清单）
  - CI pipeline 规范、对外质量承诺、bug 响应 SLA、维护者纪律

### 修改

- `CHANGELOG.md` — 在顶部新增 `[2.0.0] - 规划中` 段落，链回三份规范

## 与战略的关系

| 用户顾虑 | 在规范中如何回应 |
|---|---|
| SG 难写 | spec §3 强制 raw string literal + record + ForAttributeWithMetadataName，去除常见样板 |
| 生成代码难读 | spec §3.3 必须 `.g.cs` + auto-generated 头部，IDE 可 F12 |
| 用户配置麻烦 | spec §2.1 标准 csproj 模板把 generator 打到 `analyzers/dotnet/cs`，用户引包即生效 |
| 发包后频繁打 patch | quality §1 八层保证 + §2 量化阈值，stable 准入清单严格 |
| 边界场景遗漏 | quality §1.2 EDGE_CASES 清单 + §1.3 "诊断优先于沉默" 铁律 |

## 关联 Milestone

- v2.0.0 - Source Generator 化（Epic）
- v2.0 Sprint 0 - 质量基础设施 → 下一步将基于本规划拆子 issue

## Checklist

- [x] 文档已通过 markdown lint
- [x] 已链接到 Epic #182
- [x] CHANGELOG 已更新
- [ ] Reviewer 确认规划与战略一致
- [ ] Reviewer 确认 Sprint 时间线合理
- [ ] Reviewer 确认 stable 准入阈值可达成

## Notes

本 PR **仅含文档**，零代码变更。合并后基于本规划开始 Sprint 0 实施。
