### PR TITLE
feat(transport): introduce Skywalker.Transport.Grpc package (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
 
 ## [Unreleased]
 
+### Added
+
+- **`Skywalker.Transport.Grpc`** 新增包：基于 gRPC bidi stream 的 `ITransport` 实现（client side），与业务消息 schema 完全解耦。配合 `Skywalker.Messaging` 即可在 v2 SDK 中以「公网穿透 + HTTPS」替代 NetMQ 跨主机部署。详见 [#203](https://github.com/dengxuan/Skywalker/issues/203)。
+  - 严格遵守 `docs/modules/transport.md` 中的 4 条 transport 铁律（读循环只路由 Acks、单次 send 失败 ≠ 断连、CT 仅作用于 pre-wire、唯一断开判定 = 读循环异常）。
+  - 内置带 jitter 的指数退避重连。
+  - DI 扩展：`services.AddGrpcTransport(name, configure)`。
+
 ### Removed
 
 - **BREAKING**：移除 `Skywalker.Ddd.Application` 对 [AutoMapper](https://github.com/AutoMapper/AutoMapper) 的依赖（AutoMapper 自 v15 起转向商业授权）。

--- a/Skywalker.sln
+++ b/Skywalker.sln
@@ -179,6 +179,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Messaging.Abstrac
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Messaging", "src\Skywalker.Messaging\Skywalker.Messaging.csproj", "{F59AD99E-1CA7-495E-8606-1A8651CC2744}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Transport.Grpc", "src\Skywalker.Transport.Grpc\Skywalker.Transport.Grpc.csproj", "{947FFAD0-4C9C-4A63-B219-613E3D711833}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Transport.Grpc.Tests", "tests\Skywalker.Transport.Grpc.Tests\Skywalker.Transport.Grpc.Tests.csproj", "{25224B12-C807-48FD-9B14-AC916AF3E933}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1197,6 +1201,30 @@ Global
 		{F59AD99E-1CA7-495E-8606-1A8651CC2744}.Release|x64.Build.0 = Release|Any CPU
 		{F59AD99E-1CA7-495E-8606-1A8651CC2744}.Release|x86.ActiveCfg = Release|Any CPU
 		{F59AD99E-1CA7-495E-8606-1A8651CC2744}.Release|x86.Build.0 = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|x64.Build.0 = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Debug|x86.Build.0 = Debug|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|Any CPU.Build.0 = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|x64.ActiveCfg = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|x64.Build.0 = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|x86.ActiveCfg = Release|Any CPU
+		{947FFAD0-4C9C-4A63-B219-613E3D711833}.Release|x86.Build.0 = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|x64.Build.0 = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Debug|x86.Build.0 = Debug|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|x64.ActiveCfg = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|x64.Build.0 = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|x86.ActiveCfg = Release|Any CPU
+		{25224B12-C807-48FD-9B14-AC916AF3E933}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1288,6 +1316,8 @@ Global
 		{E36B7E3D-4B32-408C-878A-67FE38C9F9C1} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
 		{802DA503-767C-4632-A92F-08B5B83C9865} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
 		{F59AD99E-1CA7-495E-8606-1A8651CC2744} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{947FFAD0-4C9C-4A63-B219-613E3D711833} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{25224B12-C807-48FD-9B14-AC916AF3E933} = {CAE4AA71-0C04-4DE4-BC63-54217950DE9A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1448BD59-570D-4D37-831B-C0872E82B643}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,6 +55,10 @@
   <PropertyGroup Label="Third-Party">
     <CastleCoreVersion>5.1.1</CastleCoreVersion>
     <FluentValidationVersion>11.9.0</FluentValidationVersion>
+    <GoogleProtobufVersion>3.28.3</GoogleProtobufVersion>
+    <GrpcNetClientVersion>2.66.0</GrpcNetClientVersion>
+    <GrpcAspNetCoreVersion>2.66.0</GrpcAspNetCoreVersion>
+    <GrpcToolsVersion>2.66.0</GrpcToolsVersion>
     <MessagePackVersion>3.1.3</MessagePackVersion>
     <NetMQVersion>4.0.1.13</NetMQVersion>
     <PomeloEntityFrameworkCoreMySqlVersion>9.0.0</PomeloEntityFrameworkCoreMySqlVersion>

--- a/src/Skywalker.Transport.Grpc/Microsoft/Extensions/DependencyInjection/GrpcTransportServiceCollectionExtensions.cs
+++ b/src/Skywalker.Transport.Grpc/Microsoft/Extensions/DependencyInjection/GrpcTransportServiceCollectionExtensions.cs
@@ -1,0 +1,91 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Skywalker.Transport;
+using Skywalker.Transport.Grpc;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// DI 扩展：注册命名的 gRPC transport。
+/// </summary>
+public static class GrpcTransportServiceCollectionExtensions
+{
+    /// <summary>
+    /// 注册一个命名的 gRPC client transport。一个进程可注册多个，按 <paramref name="name"/> 区分。
+    /// 同一个 <paramref name="name"/> 同时充当上层 messaging channel 的 transport key。
+    /// </summary>
+    public static IServiceCollection AddGrpcTransport(
+        this IServiceCollection services,
+        string name,
+        Action<GrpcTransportOptions> configure)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        EnsureRegistry(services);
+
+        var options = new GrpcTransportOptions();
+        configure(options);
+        if (options.ServerAddress is null)
+        {
+            throw new ArgumentException(
+                $"{nameof(GrpcTransportOptions.ServerAddress)} must be set when registering gRPC transport '{name}'.",
+                nameof(configure));
+        }
+
+        services.AddKeyedSingleton(name, options);
+        services.AddSingleton<ITransport>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<GrpcTransport>();
+            logger.LogInformation("gRPC transport '{Name}' starting; server={Server}", name, options.ServerAddress);
+            return new GrpcTransport(name, options, logger);
+        });
+
+        return services;
+    }
+
+    private static void EnsureRegistry(IServiceCollection services)
+    {
+        // 与 NetMq 保持一致：复用 Skywalker.Transport.NetMq 内的 TransportRegistry 实现。
+        // 该类型为 internal，不能在此处直接 new。约定：调用方至少要先调用一次任意
+        // AddNetMq* 或在自己的 composition root 里注册一个 ITransportRegistry。
+        // 为了让 AddGrpcTransport 单独使用也能工作，提供一个轻量回退实现。
+        services.TryAddSingleton<ITransportRegistry, DefaultTransportRegistry>();
+    }
+
+    private sealed class DefaultTransportRegistry : ITransportRegistry
+    {
+        private readonly Dictionary<string, ITransport> _transports;
+
+        public DefaultTransportRegistry(IEnumerable<ITransport> transports)
+        {
+            _transports = new Dictionary<string, ITransport>(StringComparer.Ordinal);
+            foreach (var t in transports)
+            {
+                if (!_transports.TryAdd(t.Name, t))
+                {
+                    throw new InvalidOperationException($"Duplicate transport name registered: {t.Name}");
+                }
+            }
+        }
+
+        public ITransport Get(string name) =>
+            _transports.TryGetValue(name, out var t)
+                ? t
+                : throw new KeyNotFoundException($"Transport '{name}' not registered.");
+
+        public bool TryGet(string name, out ITransport transport)
+        {
+            if (_transports.TryGetValue(name, out var t))
+            {
+                transport = t;
+                return true;
+            }
+            transport = null!;
+            return false;
+        }
+    }
+}

--- a/src/Skywalker.Transport.Grpc/Protos/skywalker_bidi.proto
+++ b/src/Skywalker.Transport.Grpc/Protos/skywalker_bidi.proto
@@ -1,0 +1,35 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+//
+// Skywalker.Transport.Grpc 内部 wire 协议。
+// 本 .proto **故意**保持极简：只承载「字节帧」概念，不感知任何业务消息类型，
+// 把序列化与协议语义留给上层 Skywalker.Messaging。
+//
+// 这样设计的好处：
+//   1) Skywalker.Transport.Grpc 不依赖任何业务 proto / 业务包；
+//   2) 业务侧（gaming / payment / 任意第三方）可以选择 MessagePack、Protobuf
+//      甚至 JSON 作为消息格式，wire 不变；
+//   3) 一条 ITransport.SendAsync(frames) 调用 = 多条 Frame，
+//      最后一帧 end_of_message=true 标记消息边界。
+syntax = "proto3";
+
+package skywalker.transport.grpc.v1;
+
+option csharp_namespace = "Skywalker.Transport.Grpc.Protocol";
+
+// 双向流式 RPC：客户端与服务端各自从对端读到一连串 Frame，
+// 同一逻辑消息的多帧按发送顺序到达，服务端实现需保证「写入顺序 = 接收顺序」
+// （对单条 stream 内的多帧消息必然成立；跨消息无序由上层处理）。
+service Bidi {
+  rpc Connect(stream Frame) returns (stream Frame);
+}
+
+// 一帧 = 一段不透明字节。多帧组成一条 ITransport.TransportMessage。
+message Frame {
+  // 帧负载。可以为空（空消息允许，由上层语义决定是否合法）。
+  bytes payload = 1;
+
+  // true 表示该帧是当前 TransportMessage 的最后一帧。
+  // 接收方应在该位为 true 时把累积的所有帧组装成一条 TransportMessage 投递给上层。
+  bool end_of_message = 2;
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker.Transport.Grpc.csproj
+++ b/src/Skywalker.Transport.Grpc/Skywalker.Transport.Grpc.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace></RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
+    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcNetClientVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Skywalker.Transport.Abstractions\Skywalker.Transport.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 同时生成 Client + Server stub：服务端实现可由测试或上层应用按需使用，
+         运行时除 Grpc.Core.Api（Grpc.Net.Client 间接依赖）外不引入新依赖。 -->
+    <Protobuf Include="Protos\skywalker_bidi.proto" GrpcServices="Both" />
+  </ItemGroup>
+
+</Project>

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcTransport.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcTransport.cs
@@ -1,0 +1,300 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// 基于 gRPC bidi stream 的 <see cref="ITransport"/> 实现（client side）。
+///
+/// 设计要点（必须满足 <c>docs/modules/transport.md</c> 中描述的「Transport 实现者四条铁律」）：
+/// <list type="number">
+///   <item>读循环只把帧写入 inbound channel；不阻塞、不调用业务 handler（铁律 #1）。</item>
+///   <item><see cref="SendAsync"/> 失败只抛 <see cref="TransportSendException"/>，
+///         不主动触发 <see cref="PeerConnectionChanged"/>（铁律 #2）。</item>
+///   <item><see cref="SendAsync"/> 的 <c>cancellationToken</c> 仅用于 pre-wire（等连接、等写锁），
+///         一旦开始 <c>RequestStream.WriteAsync</c> 即不再传 CT 给底层（铁律 #3）。</item>
+///   <item>唯一的「连接挂掉」判定 = 读循环 <c>ResponseStream</c> 抛异常 / 自然结束（铁律 #4）。</item>
+/// </list>
+///
+/// 对端模型：本 transport 视服务端 <see cref="GrpcTransportOptions.ServerAddress"/> 为唯一对端，
+/// <see cref="PeerId"/> = ServerAddress 字符串。Connected/Disconnected 事件在
+/// 读循环开始/结束（含每一次重连周期）时触发。
+/// </summary>
+public sealed class GrpcTransport : ITransport
+{
+    private readonly GrpcTransportOptions _options;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly Channel<TransportMessage> _inChannel = Channel.CreateUnbounded<TransportMessage>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+    private readonly CancellationTokenSource _lifetimeCts = new();
+    private readonly TaskCompletionSource<bool> _firstConnectTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly PeerId _serverPeer;
+    private readonly Task _runLoop;
+
+    private GrpcChannel? _channel;
+    private AsyncDuplexStreamingCall<Frame, Frame>? _call;
+    private int _disposed;
+
+    /// <summary>
+    /// 创建一个 gRPC transport。构造完成后立刻在后台启动连接 + 读循环。
+    /// </summary>
+    public GrpcTransport(string name, GrpcTransportOptions options, ILogger<GrpcTransport>? logger = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.ServerAddress is null)
+        {
+            throw new ArgumentException($"{nameof(GrpcTransportOptions.ServerAddress)} is required.", nameof(options));
+        }
+
+        Name = name;
+        _options = options;
+        _logger = (ILogger?)logger ?? NullLogger<GrpcTransport>.Instance;
+        _serverPeer = new PeerId(options.ServerAddress.ToString());
+        _runLoop = Task.Run(RunAsync);
+    }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public event EventHandler<PeerConnectionEvent>? PeerConnectionChanged;
+
+    /// <inheritdoc />
+    public ValueTask SendAsync(PeerId target, IReadOnlyList<ReadOnlyMemory<byte>> frames, CancellationToken cancellationToken = default)
+    {
+        if (_disposed != 0)
+        {
+            return ValueTask.FromException(new ObjectDisposedException(nameof(GrpcTransport)));
+        }
+        if (frames is null || frames.Count == 0)
+        {
+            return ValueTask.FromException(new ArgumentException("frames must not be empty", nameof(frames)));
+        }
+
+        return SendCoreAsync(frames, cancellationToken);
+    }
+
+    private async ValueTask SendCoreAsync(IReadOnlyList<ReadOnlyMemory<byte>> frames, CancellationToken ct)
+    {
+        // ===== Pre-wire #1：等待首次连接成功（铁律 #3 允许 CT 在此阶段生效）=====
+        if (!_firstConnectTcs.Task.IsCompletedSuccessfully)
+        {
+            await _firstConnectTcs.Task.WaitAsync(ct).ConfigureAwait(false);
+        }
+
+        // ===== Pre-wire #2：争抢写锁（铁律 #3 允许 CT 在此阶段生效）=====
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var call = _call;
+            if (call is null)
+            {
+                throw new TransportSendException("gRPC transport is not connected.");
+            }
+
+            // ===== 已开写：CT 不再生效（铁律 #3）=====
+            // 整组帧必须原子写出，最后一帧 EndOfMessage=true。
+            // ⚠️ 即使调用方取消 ct，下面的 WriteAsync 也不会传 ct——
+            // 否则会触发 HTTP/2 RST_STREAM，把整条 bidi stream 上其他 in-flight 请求一起拖死。
+            for (var i = 0; i < frames.Count; i++)
+            {
+                var frame = new Frame
+                {
+                    Payload = ByteString.CopyFrom(frames[i].Span),
+                    EndOfMessage = (i == frames.Count - 1),
+                };
+                try
+                {
+                    await call.RequestStream.WriteAsync(frame).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // 铁律 #2：单次写失败只通知调用方，不主动断连。
+                    throw new TransportSendException("Failed to write frame to gRPC stream.", ex);
+                }
+            }
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TransportMessage> ReceiveAsync(CancellationToken cancellationToken = default)
+        => _inChannel.Reader.ReadAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try { _lifetimeCts.Cancel(); } catch { /* ignore */ }
+
+        // 重要：必须先把当前的 streaming call dispose 掉，才能保证 ReadLoopAsync
+        // 里的 `await foreach` 立刻抛 OperationCanceledException 退出；
+        // 仅 cancel _lifetimeCts 不一定能撕开 HTTP/2 stream（取决于网络 IO 状态）。
+        await CleanupCallAsync().ConfigureAwait(false);
+
+        try { await _runLoop.ConfigureAwait(false); } catch { /* run loop swallows, but be safe */ }
+
+        // 阻塞中的 SendAsync 必须能从 _firstConnectTcs 中醒来。
+        _firstConnectTcs.TrySetException(new ObjectDisposedException(nameof(GrpcTransport)));
+
+        _writeLock.Dispose();
+        _lifetimeCts.Dispose();
+    }
+
+    /// <summary>
+    /// 主循环：连接 → 读循环 → 断开 → 退避 → 重连。是本 transport 中**唯一**
+    /// 的「连接挂掉」判定源（铁律 #4）。
+    /// </summary>
+    private async Task RunAsync()
+    {
+        var attempt = 0;
+        while (!_lifetimeCts.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectOnceAsync().ConfigureAwait(false);
+                attempt = 0; // 成功重置退避
+                _firstConnectTcs.TrySetResult(true);
+                RaisePeerEvent(PeerConnectionState.Connected);
+
+                await ReadLoopAsync(_call!).ConfigureAwait(false);
+                // 服务端正常 close stream：当作一次断开，进入重连退避。
+            }
+            catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "gRPC transport '{Name}' connection error.", Name);
+            }
+
+            await CleanupCallAsync().ConfigureAwait(false);
+
+            // 仅在「曾经成功连接过」之后才发 Disconnected；否则只在退避结束后下一轮再 Connected。
+            if (_firstConnectTcs.Task.IsCompletedSuccessfully)
+            {
+                RaisePeerEvent(PeerConnectionState.Disconnected);
+            }
+
+            if (!_options.Reconnect.Enabled)
+            {
+                break;
+            }
+
+            attempt++;
+            try
+            {
+                await Task.Delay(ComputeBackoff(attempt), _lifetimeCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _inChannel.Writer.TryComplete();
+    }
+
+    private async Task ConnectOnceAsync()
+    {
+        var channelOptions = new GrpcChannelOptions();
+        _options.ConfigureChannel?.Invoke(channelOptions);
+
+        _channel = GrpcChannel.ForAddress(_options.ServerAddress!, channelOptions);
+        var client = new Bidi.BidiClient(_channel);
+        if (!string.IsNullOrEmpty(_options.Authority))
+        {
+            client = client.WithHost(_options.Authority);
+        }
+
+        var headers = new Metadata();
+        foreach (var kv in _options.Metadata)
+        {
+            headers.Add(kv.Key, kv.Value);
+        }
+
+        var callOptions = new CallOptions(headers: headers, cancellationToken: _lifetimeCts.Token);
+
+        _call = client.Connect(callOptions);
+
+        // 注意：不能用 _call.ResponseHeadersAsync 作为「已连接」的判断信号——
+        // 在我们的协议里，服务端只在业务代码主动写响应时才会发送 response headers，
+        // 一个空闲的 bidi stream 客户端会因此永远拿不到 headers。
+        // gRPC 自身只在「第一次写」时才真正建立 HTTP/2 流，因此 client.Connect 返回即视为「已连接」，
+        // 真实的网络错误会在后续 RequestStream.WriteAsync / ResponseStream.MoveNext 时抛出。
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    private async Task ReadLoopAsync(AsyncDuplexStreamingCall<Frame, Frame> call)
+    {
+        var buffer = new List<ReadOnlyMemory<byte>>();
+        await foreach (var frame in call.ResponseStream.ReadAllAsync(_lifetimeCts.Token).ConfigureAwait(false))
+        {
+            buffer.Add(frame.Payload.ToByteArray());
+            if (frame.EndOfMessage)
+            {
+                _inChannel.Writer.TryWrite(new TransportMessage(_serverPeer, buffer.ToArray()));
+                buffer.Clear();
+            }
+        }
+        // 流自然结束：相当于服务端关流；上层把它视为一次断开。
+    }
+
+    private async Task CleanupCallAsync()
+    {
+        var call = Interlocked.Exchange(ref _call, null);
+        if (call is not null)
+        {
+            // 注意：不 await RequestStream.CompleteAsync()——若 stream 已被对端撕掉，
+            // 该调用会无限阻塞。直接 Dispose() 会立即取消底层 HTTP/2 stream。
+            try { call.Dispose(); } catch { /* ignore */ }
+        }
+
+        var channel = Interlocked.Exchange(ref _channel, null);
+        if (channel is not null)
+        {
+            try { await channel.ShutdownAsync().ConfigureAwait(false); } catch { /* ignore */ }
+            channel.Dispose();
+        }
+    }
+
+    private TimeSpan ComputeBackoff(int attempt)
+    {
+        var p = _options.Reconnect;
+        var baseMs = p.InitialBackoff.TotalMilliseconds * Math.Pow(p.Multiplier, attempt - 1);
+        baseMs = Math.Min(p.MaxBackoff.TotalMilliseconds, baseMs);
+        var jitterRange = baseMs * Math.Clamp(p.Jitter, 0, 1);
+        var jitter = (Random.Shared.NextDouble() * 2 - 1) * jitterRange;
+        return TimeSpan.FromMilliseconds(Math.Max(0, baseMs + jitter));
+    }
+
+    private void RaisePeerEvent(PeerConnectionState state)
+    {
+        try
+        {
+            PeerConnectionChanged?.Invoke(this, new PeerConnectionEvent(_serverPeer, state));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PeerConnectionChanged handler threw for {Peer}", _serverPeer);
+        }
+    }
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcTransportOptions.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcTransportOptions.cs
@@ -1,0 +1,53 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using Grpc.Net.Client;
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// <see cref="GrpcTransport"/> 的配置选项。
+/// </summary>
+public sealed class GrpcTransportOptions
+{
+    /// <summary>
+    /// 服务端地址。必填。例如 <c>https://api.example.com</c>。
+    /// </summary>
+    public Uri? ServerAddress { get; set; }
+
+    /// <summary>
+    /// 覆盖 HTTP/2 <c>:authority</c> 头。通常不需要设置；常见用法是
+    /// 透过反向代理时把 <c>:authority</c> 强制为后端真实主机名。
+    /// </summary>
+    public string? Authority { get; set; }
+
+    /// <summary>
+    /// 每次发起 bidi 调用时附带的 metadata（HTTP/2 头）。常用来携带鉴权信息，
+    /// 例如 <c>{ "authorization", "Bearer ..." }</c>。
+    /// 该集合在每次重连时会被重新读取一次（允许实现按需轮换 token）。
+    /// </summary>
+    public IList<KeyValuePair<string, string>> Metadata { get; } = new List<KeyValuePair<string, string>>();
+
+    /// <summary>
+    /// 保留字段：未来用于显式的连接超时控制。
+    /// 当前实现把「<see cref="GrpcTransport"/> 已构造、bidi call 对象已创建」视为已连接，
+    /// 真实的网络连通性会在第一次 <c>SendAsync</c> 时由 HTTP/2 stream 建立过程暴露。
+    /// 默认 10 秒。
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// 重连策略。默认开启，指数退避。详见 <see cref="ReconnectPolicy"/>。
+    /// </summary>
+    public ReconnectPolicy Reconnect { get; set; } = ReconnectPolicy.Default;
+
+    /// <summary>
+    /// 允许调用方进一步定制 <see cref="GrpcChannelOptions"/>，例如：
+    /// <list type="bullet">
+    ///   <item>替换 <c>HttpHandler</c> 以接入自定义 HTTPS 校验</item>
+    ///   <item>设置 <c>Credentials</c> / <c>UnsafeUseInsecureChannelCallCredentials</c></item>
+    ///   <item>设置 <c>MaxReceiveMessageSize</c> / <c>MaxSendMessageSize</c></item>
+    /// </list>
+    /// </summary>
+    public Action<GrpcChannelOptions>? ConfigureChannel { get; set; }
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/ReconnectPolicy.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/ReconnectPolicy.cs
@@ -1,0 +1,47 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// gRPC transport 重连策略。指数退避 + 抖动。
+/// </summary>
+public sealed class ReconnectPolicy
+{
+    /// <summary>
+    /// 是否允许在底层 stream 断开后自动重连。默认 <c>true</c>。
+    /// 设为 <c>false</c> 时一旦读循环退出，transport 即关闭、<see cref="GrpcTransport.ReceiveAsync"/>
+    /// 的迭代结束、后续 <see cref="GrpcTransport.SendAsync"/> 抛出 <see cref="TransportSendException"/>。
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// 第一次重连前等待的时长。默认 1 秒。
+    /// </summary>
+    public TimeSpan InitialBackoff { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// 退避时长上限。默认 30 秒。
+    /// </summary>
+    public TimeSpan MaxBackoff { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// 退避增长因子。默认 2.0（每次失败后等待时长翻倍，直到 <see cref="MaxBackoff"/>）。
+    /// </summary>
+    public double Multiplier { get; set; } = 2.0;
+
+    /// <summary>
+    /// 抖动比例 [0, 1]。默认 0.2，表示在 ±20% 范围内随机扰动。用于避免雷鸣群效应。
+    /// </summary>
+    public double Jitter { get; set; } = 0.2;
+
+    /// <summary>
+    /// 默认策略：1s → 2s → 4s → … → 30s 上限，±20% 抖动。
+    /// </summary>
+    public static ReconnectPolicy Default => new();
+
+    /// <summary>
+    /// 不重连：一次断开即 transport 终结。常用于测试或一次性脚本。
+    /// </summary>
+    public static ReconnectPolicy Disabled => new() { Enabled = false };
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/TransportSendException.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/TransportSendException.cs
@@ -1,0 +1,16 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// 单次 <see cref="ITransport.SendAsync"/> 失败时抛出。
+/// 抛出此异常**不**意味着连接已断开（参见 <c>docs/modules/transport.md</c> 铁律 #2）：
+/// transport 会保持当前 stream，调用方可以稍后重试。
+/// 真正的断连判定只发生在读循环（铁律 #4）。
+/// </summary>
+public sealed class TransportSendException : Exception
+{
+    public TransportSendException(string message) : base(message) { }
+    public TransportSendException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/tests/Skywalker.Transport.Grpc.Tests/GrpcTransportTests.cs
+++ b/tests/Skywalker.Transport.Grpc.Tests/GrpcTransportTests.cs
@@ -1,0 +1,145 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using Google.Protobuf;
+using Microsoft.Extensions.Logging.Abstractions;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc.Tests;
+
+/// <summary>
+/// 验证 <see cref="GrpcTransport"/> 满足 4 条铁律及基础语义。
+/// 「服务端 close stream → reconnect」端到端验证更适合放在 integration test。
+/// </summary>
+public class GrpcTransportTests
+{
+    private static GrpcTransport CreateTransport(Uri serverAddress, Action<GrpcTransportOptions>? configure = null)
+    {
+        var options = new GrpcTransportOptions
+        {
+            ServerAddress = serverAddress,
+            ConnectTimeout = TimeSpan.FromSeconds(5),
+            Reconnect = ReconnectPolicy.Disabled,
+        };
+        configure?.Invoke(options);
+        return new GrpcTransport("test", options, NullLogger<GrpcTransport>.Instance);
+    }
+
+    private static IReadOnlyList<ReadOnlyMemory<byte>> Frames(params byte[][] payloads)
+        => payloads.Select(p => (ReadOnlyMemory<byte>)p).ToArray();
+
+    /// <summary>多帧消息：3 帧按序到达服务端，且服务端识别出「一条 3 帧消息」。</summary>
+    [Fact]
+    public async Task SendAsync_MultiFrame_ArrivesAsSingleMessage()
+    {
+        await using var server = await TestServerFixture.StartAsync();
+        await using var transport = CreateTransport(server.Address);
+
+        await transport.SendAsync(PeerId.Empty, Frames([1], [2, 2], [3, 3, 3]));
+
+        await WaitFor(() => !server.Behavior.ReceivedMessages.IsEmpty);
+
+        Assert.Single(server.Behavior.ReceivedMessages);
+        var msg = server.Behavior.ReceivedMessages.First();
+        Assert.Equal(3, msg.Count);
+        Assert.Equal(new byte[] { 1 }, msg[0]);
+        Assert.Equal(new byte[] { 2, 2 }, msg[1]);
+        Assert.Equal(new byte[] { 3, 3, 3 }, msg[2]);
+    }
+
+    /// <summary>铁律 #3：写入开始后取消 CT，写入仍必须完成、stream 不断。</summary>
+    [Fact]
+    public async Task SendAsync_CancelAfterWriteStarted_DoesNotTearDownStream()
+    {
+        await using var server = await TestServerFixture.StartAsync();
+        await using var transport = CreateTransport(server.Address);
+
+        await transport.SendAsync(PeerId.Empty, Frames([0]));
+        await WaitFor(() => server.Behavior.ReceivedMessages.Count >= 1);
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = transport.SendAsync(PeerId.Empty, Frames(new byte[10], new byte[10], new byte[10]), cts.Token);
+        cts.Cancel();
+        await sendTask;
+
+        await transport.SendAsync(PeerId.Empty, Frames([42]));
+
+        await WaitFor(() => server.Behavior.ReceivedMessages.Count >= 3);
+        Assert.True(server.Behavior.ReceivedMessages.Count >= 3,
+            $"Expected at least 3 messages, got {server.Behavior.ReceivedMessages.Count}");
+    }
+
+    /// <summary>铁律 #4：PeerConnectionChanged 在首次连接成功后触发 Connected。</summary>
+    [Fact]
+    public async Task PeerConnectionChanged_FiresConnectedOnFirstConnect()
+    {
+        await using var server = await TestServerFixture.StartAsync();
+        var events = new List<PeerConnectionEvent>();
+        await using var transport = CreateTransport(server.Address);
+        transport.PeerConnectionChanged += (_, e) =>
+        {
+            lock (events) events.Add(e);
+        };
+
+        await transport.SendAsync(PeerId.Empty, Frames([1]));
+        await WaitFor(() => { lock (events) return events.Count >= 1; });
+
+        lock (events)
+        {
+            Assert.NotEmpty(events);
+            Assert.Equal(PeerConnectionState.Connected, events[0].State);
+            Assert.Equal(server.Address.ToString(), events[0].Peer.Value);
+        }
+    }
+
+    /// <summary>服务端推一帧给 client，client 必须能在 ReceiveAsync 上读到。</summary>
+    [Fact]
+    public async Task ReceiveAsync_DeliversServerPushedMessage()
+    {
+        await using var server = await TestServerFixture.StartAsync(b =>
+        {
+            b.OnConnect = async response =>
+            {
+                await response.WriteAsync(new Frame { Payload = ByteString.CopyFrom([0x10]), EndOfMessage = false });
+                await response.WriteAsync(new Frame { Payload = ByteString.CopyFrom([0x20]), EndOfMessage = true });
+            };
+        });
+
+        await using var transport = CreateTransport(server.Address);
+        await transport.SendAsync(PeerId.Empty, Frames([0]));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await foreach (var msg in transport.ReceiveAsync(cts.Token))
+        {
+            Assert.Equal(2, msg.Frames.Count);
+            Assert.Equal(new byte[] { 0x10 }, msg.Frames[0].ToArray());
+            Assert.Equal(new byte[] { 0x20 }, msg.Frames[1].ToArray());
+            return;
+        }
+        Assert.Fail("Did not receive any message from the server.");
+    }
+
+    /// <summary>Disposed 后再发送应抛 <see cref="ObjectDisposedException"/>。</summary>
+    [Fact]
+    public async Task SendAsync_OnDisposedTransport_ThrowsObjectDisposedException()
+    {
+        await using var server = await TestServerFixture.StartAsync();
+        var transport = CreateTransport(server.Address);
+        await transport.SendAsync(PeerId.Empty, Frames([1]));
+
+        await transport.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await transport.SendAsync(PeerId.Empty, Frames([2])));
+    }
+
+    private static async Task WaitFor(Func<bool> condition, double timeoutSec = 10)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(timeoutSec);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+}

--- a/tests/Skywalker.Transport.Grpc.Tests/Skywalker.Transport.Grpc.Tests.csproj
+++ b/tests/Skywalker.Transport.Grpc.Tests/Skywalker.Transport.Grpc.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- 测试代码不强制 nullable 公开 API 之类的严格检查 -->
+    <Features>strict</Features>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+
+    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcAspNetCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Skywalker.Transport.Grpc\Skywalker.Transport.Grpc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Skywalker.Transport.Grpc.Tests/TestServerFixture.cs
+++ b/tests/Skywalker.Transport.Grpc.Tests/TestServerFixture.cs
@@ -1,0 +1,134 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc.Tests;
+
+/// <summary>
+/// 测试用 in-memory gRPC server。监听本机随机端口，行为通过 <see cref="BidiBehavior"/>
+/// 注入；每个测试可独立配置「服务端怎么处理一条消息」。
+/// </summary>
+internal sealed class TestServerFixture : IAsyncDisposable
+{
+    public WebApplication App { get; }
+    public BidiBehavior Behavior { get; }
+    public Uri Address { get; }
+
+    private TestServerFixture(WebApplication app, BidiBehavior behavior, Uri address)
+    {
+        App = app;
+        Behavior = behavior;
+        Address = address;
+    }
+
+    public static async Task<TestServerFixture> StartAsync(Action<BidiBehavior>? configure = null)
+    {
+        var behavior = new BidiBehavior();
+        configure?.Invoke(behavior);
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o =>
+        {
+            o.Listen(IPAddress.Loopback, 0, lo => lo.Protocols = HttpProtocols.Http2);
+        });
+        builder.Services.AddGrpc();
+        builder.Services.AddSingleton(behavior);
+
+        var app = builder.Build();
+        app.MapGrpcService<TestBidiService>();
+
+        await app.StartAsync().ConfigureAwait(false);
+
+        var addresses = app.Services.GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>()
+            .Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>()!
+            .Addresses;
+        var address = new Uri(addresses.First());
+        return new TestServerFixture(app, behavior, address);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await App.StopAsync().ConfigureAwait(false);
+        await App.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// 由测试逐项配置的 gRPC bidi server 行为。
+/// </summary>
+internal sealed class BidiBehavior
+{
+    /// <summary>每收到一帧就调用一次。返回值是要发回的帧（null 表示不回）。</summary>
+    public Func<Frame, IServerStreamWriter<Frame>, Task>? OnFrame { get; set; }
+
+    /// <summary>读循环开始前的钩子。可用于让 server 主动给 client 推送一些消息。</summary>
+    public Func<IServerStreamWriter<Frame>, Task>? OnConnect { get; set; }
+
+    /// <summary>读完客户端流后是否主动关流（自然结束）。默认 true，正常结束 stream。</summary>
+    public bool CompleteOnClientFinish { get; set; } = true;
+
+    /// <summary>统计：服务端总共收到多少帧。</summary>
+    public int ReceivedFrameCount;
+
+    /// <summary>统计：服务端收到的所有完整 message（按 EndOfMessage 边界划分）。</summary>
+    public ConcurrentBag<List<byte[]>> ReceivedMessages { get; } = new();
+}
+
+internal sealed class TestBidiService : Bidi.BidiBase
+{
+    private readonly BidiBehavior _behavior;
+
+    public TestBidiService(BidiBehavior behavior) => _behavior = behavior;
+
+    public override async Task Connect(IAsyncStreamReader<Frame> requestStream, IServerStreamWriter<Frame> responseStream, ServerCallContext context)
+    {
+        if (_behavior.OnConnect is not null)
+        {
+            await _behavior.OnConnect(responseStream).ConfigureAwait(false);
+        }
+
+        var current = new List<byte[]>();
+        try
+        {
+            while (await requestStream.MoveNext(context.CancellationToken).ConfigureAwait(false))
+            {
+                var frame = requestStream.Current;
+                Interlocked.Increment(ref _behavior.ReceivedFrameCount);
+                current.Add(frame.Payload.ToByteArray());
+                if (frame.EndOfMessage)
+                {
+                    _behavior.ReceivedMessages.Add(current);
+                    current = new List<byte[]>();
+                }
+
+                if (_behavior.OnFrame is not null)
+                {
+                    await _behavior.OnFrame(frame, responseStream).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // client cancelled or server shutting down - normal
+        }
+
+        if (!_behavior.CompleteOnClientFinish)
+        {
+            // 让服务端持续 hold 住，以模拟 server side hang 的场景
+            try { await Task.Delay(Timeout.Infinite, context.CancellationToken).ConfigureAwait(false); }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Skywalker integration epic [#201]. Introduces a new package **`Skywalker.Transport.Grpc`** — a gRPC bidi-stream based `ITransport` implementation (client side), completely decoupled from any business message schema.

Closes #203 · Refs #201 · Depends on #205 (CT contract)

## Wire protocol

```proto
syntax = "proto3";
package skywalker.transport.grpc.v1;
option csharp_namespace = "Skywalker.Transport.Grpc.Protocol";

service Bidi {
  rpc Connect(stream Frame) returns (stream Frame);
}

message Frame {
  bytes payload         = 1;
  bool  end_of_message  = 2;
}
```

A multi-frame `TransportMessage` becomes N consecutive `Frame`s, the last with `end_of_message = true`.

## Invariants enforced

`docs/modules/transport.md` (added in #205) lists 4 mandatory invariants for every `ITransport` implementation. `GrpcTransport` enforces them at the exact lines below:

| # | Invariant | Where |
|---|---|---|
| 1 | Read loop only routes Acks (no inline business code) | `ReadLoopAsync` only writes to `_inChannel` |
| 2 | A single send/handler failure must NOT cause a disconnect | `SendCoreAsync` wraps `WriteAsync` in `TransportSendException` only |
| 3 | `cancellationToken` is honoured ONLY before the wire is committed (RST_STREAM would tear down all in-flight requests on the same HTTP/2 stream) | `await call.RequestStream.WriteAsync(frame)` — intentionally **without** ct |
| 4 | The read loop is the SOLE source of truth for connection liveness | `RunAsync` is the only emitter of `Disconnected` events |

Reconnect: exponential backoff with jitter (configurable via `ReconnectPolicy`). All `Connected`/`Disconnected` events flow exclusively through the run loop.

## DI

```csharp
services.AddGrpcTransport("provider-bus", o =>
{
    o.ServerAddress = new Uri("https://api.example.com");
    o.Metadata.Add(new KeyValuePair<string, string>("authorization", "Bearer ..."));
});
```

A lightweight `DefaultTransportRegistry` is auto-registered when the consumer doesn't already provide one (so the package is usable standalone, without `Skywalker.Transport.NetMq`).

## Tests (5 / 5 passing)

`Skywalker.Transport.Grpc.Tests` uses an in-process `Grpc.AspNetCore` server on a random Kestrel port.

- `SendAsync_MultiFrame_ArrivesAsSingleMessage` — frame ordering + EndOfMessage boundary
- `SendAsync_CancelAfterWriteStarted_DoesNotTearDownStream` — invariant **#3**: cancelling ct mid-send must not break the stream
- `PeerConnectionChanged_FiresConnectedOnFirstConnect` — Connected event semantics (invariant **#4**)
- `ReceiveAsync_DeliversServerPushedMessage` — server-pushed messages survive the inbound channel
- `SendAsync_OnDisposedTransport_ThrowsObjectDisposedException` — dispose semantics

> The `server-closes-stream → reconnect` end-to-end scenario is intentionally deferred to an integration-test PR (Phase 1.5) — exercising it inside an in-process Kestrel testhost was unstable in CI.

## Out of scope (future PRs)

- Server-side `GrpcTransport` (needed for Phase 3 — `gaming-dotnet-sdk` rewrite). Tracked separately.
- `IPeerResolver` integration (Phase 1.5, [#204]).

## Acceptance

- [x] 0 warnings, 0 errors with `TreatWarningsAsErrors=true` + `Features=strict;nullablePublicOnly`
- [x] All 5 tests green
- [x] `Versions.props` centralizes Grpc + Google.Protobuf versions
- [x] `CHANGELOG.md` Unreleased entry added
- [x] No dependency on `Skywalker.Messaging` or `Skywalker.Transport.NetMq`
