### PR TITLE
feat(transport): add server-side GrpcServerTransport (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
   - 严格遵守 `docs/modules/transport.md` 中的 4 条 transport 铁律（读循环只路由 Acks、单次 send 失败 ≠ 断连、CT 仅作用于 pre-wire、唯一断开判定 = 读循环异常）。
   - 内置带 jitter 的指数退避重连。
   - DI 扩展：`services.AddGrpcTransport(name, configure)`。
+- **`Skywalker.Transport.Grpc`** 新增 server 端实现：`GrpcServerTransport` + `BidiServiceImpl`，承载多 peer 的双向流。Peer 身份由 `x-skywalker-peer-id` metadata 头标识；`SendAsync(target, frames)` 路由到对应连接，`ReceiveAsync` 产出带 `From` 的 `TransportMessage`。同样严守 4 条 transport 铁律。详见 [#203](https://github.com/dengxuan/Skywalker/issues/203)。
+  - DI 扩展：`services.AddGrpcServerTransport(name, configure?)`，配合 `app.MapGrpcService<BidiServiceImpl>()` 即可挂载。
 
 ### Removed
 

--- a/src/Skywalker.Transport.Grpc/Microsoft/Extensions/DependencyInjection/GrpcServerTransportServiceCollectionExtensions.cs
+++ b/src/Skywalker.Transport.Grpc/Microsoft/Extensions/DependencyInjection/GrpcServerTransportServiceCollectionExtensions.cs
@@ -1,0 +1,82 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Skywalker.Transport;
+using Skywalker.Transport.Grpc;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// DI 扩展：注册命名的 gRPC server transport。需要配合用户自己的
+/// <c>app.MapGrpcService&lt;BidiServiceImpl&gt;()</c>。
+/// </summary>
+public static class GrpcServerTransportServiceCollectionExtensions
+{
+    /// <summary>
+    /// 注册一个命名的 gRPC server transport。<paramref name="name"/> 同时充当上层 messaging channel 的 transport key。
+    /// </summary>
+    public static IServiceCollection AddGrpcServerTransport(
+        this IServiceCollection services,
+        string name,
+        Action<GrpcServerTransportOptions>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var options = new GrpcServerTransportOptions();
+        configure?.Invoke(options);
+
+        services.AddKeyedSingleton(name, options);
+
+        // 创建为单例：同时作为 ITransport（按 name 注册到 transport registry）和具体类型（给 BidiServiceImpl 注入）。
+        services.AddSingleton<GrpcServerTransport>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<GrpcServerTransport>();
+            logger.LogInformation("gRPC server transport '{Name}' starting.", name);
+            return new GrpcServerTransport(name, options, logger);
+        });
+        services.AddSingleton<ITransport>(sp => sp.GetRequiredService<GrpcServerTransport>());
+
+        // BidiServiceImpl 由 ASP.NET gRPC framework 在每次调用时实例化（scoped/transient 都行），
+        // 注册为 singleton 即可，因为它只持有 transport 引用。
+        services.TryAddSingleton<BidiServiceImpl>();
+
+        // 提供轻量 fallback registry（同 client 端）。
+        services.TryAddSingleton<ITransportRegistry, DefaultTransportRegistry>();
+        return services;
+    }
+
+    private sealed class DefaultTransportRegistry : ITransportRegistry
+    {
+        private readonly Dictionary<string, ITransport> _transports;
+
+        public DefaultTransportRegistry(IEnumerable<ITransport> transports)
+        {
+            _transports = new Dictionary<string, ITransport>(StringComparer.Ordinal);
+            foreach (var t in transports)
+            {
+                if (!_transports.TryAdd(t.Name, t))
+                {
+                    throw new InvalidOperationException($"Duplicate transport name registered: {t.Name}");
+                }
+            }
+        }
+
+        public ITransport Get(string name) =>
+            _transports.TryGetValue(name, out var t)
+                ? t
+                : throw new KeyNotFoundException($"Transport '{name}' not registered.");
+
+        public bool TryGet(string name, out ITransport transport)
+        {
+            if (_transports.TryGetValue(name, out var t))
+            {
+                transport = t;
+                return true;
+            }
+            transport = null!;
+            return false;
+        }
+    }
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/BidiServiceImpl.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/BidiServiceImpl.cs
@@ -1,0 +1,28 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using Grpc.Core;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// 用户用 <c>app.MapGrpcService&lt;BidiServiceImpl&gt;()</c> 把本类挂到 gRPC pipeline。
+/// 每条 <c>Bidi.Connect</c> 调用都被 forward 给 <see cref="GrpcServerTransport.HandleConnectAsync"/>。
+///
+/// 一个进程内可以有多个 <see cref="GrpcServerTransport"/>（按 name 区分），但每个 BidiService 实现
+/// 只对应一个 transport。如需多个 transport 端点，在不同端口/路由上注册多个派生类。
+/// </summary>
+public class BidiServiceImpl : Bidi.BidiBase
+{
+    private readonly GrpcServerTransport _transport;
+
+    public BidiServiceImpl(GrpcServerTransport transport)
+    {
+        ArgumentNullException.ThrowIfNull(transport);
+        _transport = transport;
+    }
+
+    public override Task Connect(IAsyncStreamReader<Frame> requestStream, IServerStreamWriter<Frame> responseStream, ServerCallContext context)
+        => _transport.HandleConnectAsync(requestStream, responseStream, context);
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransport.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransport.cs
@@ -1,0 +1,223 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Google.Protobuf;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// 服务端 <see cref="ITransport"/> 实现。等价于 NetMQ Router：
+/// 一个 transport 同时承接多个客户端 bidi stream，每个 stream 是一个 <see cref="PeerId"/>。
+///
+/// 工作模型：
+/// <list type="bullet">
+///   <item>由 ASP.NET Core gRPC pipeline（用户用 <c>MapGrpcService&lt;BidiServiceImpl&gt;()</c> 注册）
+///         把每条 <c>Bidi.Connect</c> RPC 转发给 <see cref="HandleConnectAsync"/>。</item>
+///   <item><see cref="HandleConnectAsync"/> 负责：注册 <see cref="PeerSession"/> → 触发 Connected →
+///         跑读循环 → 退出时触发 Disconnected → 反注册。</item>
+///   <item><see cref="SendAsync"/> 通过 <see cref="PeerId"/> 在 session 字典里查找目标 peer，
+///         在该 peer 的写锁内写出多帧。</item>
+/// </list>
+///
+/// 满足 4 条 transport 铁律（详见 <c>docs/modules/transport.md</c>）：
+/// 见每个相关方法上的中文注释。
+/// </summary>
+public sealed class GrpcServerTransport : ITransport
+{
+    private readonly GrpcServerTransportOptions _options;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<PeerId, PeerSession> _peers = new();
+    private readonly Channel<TransportMessage> _inChannel = Channel.CreateUnbounded<TransportMessage>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    private int _disposed;
+
+    public GrpcServerTransport(string name, GrpcServerTransportOptions options, ILogger<GrpcServerTransport>? logger = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(options);
+        Name = name;
+        _options = options;
+        _logger = (ILogger?)logger ?? NullLogger<GrpcServerTransport>.Instance;
+    }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public event EventHandler<PeerConnectionEvent>? PeerConnectionChanged;
+
+    /// <inheritdoc />
+    public ValueTask SendAsync(PeerId target, IReadOnlyList<ReadOnlyMemory<byte>> frames, CancellationToken cancellationToken = default)
+    {
+        if (_disposed != 0)
+        {
+            return ValueTask.FromException(new ObjectDisposedException(nameof(GrpcServerTransport)));
+        }
+        if (target.IsEmpty)
+        {
+            return ValueTask.FromException(new ArgumentException("Server transport requires explicit target PeerId.", nameof(target)));
+        }
+        if (frames is null || frames.Count == 0)
+        {
+            return ValueTask.FromException(new ArgumentException("frames must not be empty", nameof(frames)));
+        }
+
+        return SendCoreAsync(target, frames, cancellationToken);
+    }
+
+    private async ValueTask SendCoreAsync(PeerId target, IReadOnlyList<ReadOnlyMemory<byte>> frames, CancellationToken ct)
+    {
+        if (!_peers.TryGetValue(target, out var session))
+        {
+            if (_options.ThrowOnUnknownPeer)
+            {
+                // 铁律 #2：抛 TransportSendException，不发 Disconnected（peer 早就 Disconnected 过了）。
+                throw new TransportSendException($"Peer '{target}' is not connected.");
+            }
+            return;
+        }
+
+        // ===== Pre-wire：抢 peer 的写锁（铁律 #3 允许 CT 在此阶段生效）=====
+        await session.WriteLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            for (var i = 0; i < frames.Count; i++)
+            {
+                var frame = new Frame
+                {
+                    Payload = ByteString.CopyFrom(frames[i].Span),
+                    EndOfMessage = (i == frames.Count - 1),
+                };
+                try
+                {
+                    // 铁律 #3：开始写之后不再传 ct，避免 RST_STREAM 撕掉同一连接上其他写。
+                    await session.Response.WriteAsync(frame).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // 铁律 #2：单次写失败只通知调用方，不主动 Disconnected。
+                    // peer 真正断开会由该 peer 的 read loop 在 MoveNext 抛错时统一发出。
+                    throw new TransportSendException($"Failed to write frame to peer '{target}'.", ex);
+                }
+            }
+        }
+        finally
+        {
+            session.WriteLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TransportMessage> ReceiveAsync(CancellationToken cancellationToken = default)
+        => _inChannel.Reader.ReadAllAsync(cancellationToken);
+
+    /// <summary>
+    /// 由 <see cref="BidiServiceImpl"/> 调用：处理一个进来的 bidi stream，从开始到结束。
+    /// 这是该 peer 的「连接生命周期」，也是该 peer 的「断开判定」唯一来源（铁律 #4）。
+    /// </summary>
+    internal async Task HandleConnectAsync(IAsyncStreamReader<Frame> requestStream, IServerStreamWriter<Frame> responseStream, ServerCallContext context)
+    {
+        if (_disposed != 0)
+        {
+            return;
+        }
+
+        var peerId = ResolvePeerId(context);
+        var session = new PeerSession(responseStream);
+
+        if (!_peers.TryAdd(peerId, session))
+        {
+            // 同名 peer 重连：覆盖（旧的早已断了或正在断），并踢掉旧 session 的写锁。
+            _peers[peerId] = session;
+            _logger.LogInformation("Peer '{Peer}' reconnected; replacing previous session.", peerId);
+        }
+
+        RaisePeerEvent(peerId, PeerConnectionState.Connected);
+
+        try
+        {
+            // ===== 读循环：唯一的「连接还活着」判定（铁律 #1 + #4）=====
+            var buffer = new List<ReadOnlyMemory<byte>>();
+            while (await requestStream.MoveNext(context.CancellationToken).ConfigureAwait(false))
+            {
+                var frame = requestStream.Current;
+                buffer.Add(frame.Payload.ToByteArray());
+                if (frame.EndOfMessage)
+                {
+                    // 铁律 #1：只入队，不走业务 handler。
+                    _inChannel.Writer.TryWrite(new TransportMessage(peerId, buffer.ToArray()));
+                    buffer = new List<ReadOnlyMemory<byte>>();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            // client cancelled / server shutting down — 视为正常断开
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Read loop for peer '{Peer}' faulted.", peerId);
+        }
+        finally
+        {
+            _peers.TryRemove(new KeyValuePair<PeerId, PeerSession>(peerId, session));
+            session.Dispose();
+            RaisePeerEvent(peerId, PeerConnectionState.Disconnected);
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        _inChannel.Writer.TryComplete();
+        // 注意：不在此 dispose 各 peer 的 SemaphoreSlim——它们的 lifetime
+        // 与 ServerCallContext 一致，gRPC pipeline 关停时会取消相应的 cancellation token，
+        // 让 read loop 退出，由 finally 块统一清理。
+        return ValueTask.CompletedTask;
+    }
+
+    private PeerId ResolvePeerId(ServerCallContext context)
+    {
+        var entry = context.RequestHeaders?.FirstOrDefault(e =>
+            string.Equals(e.Key, _options.PeerIdMetadataKey, StringComparison.OrdinalIgnoreCase));
+        if (entry is { Value: { Length: > 0 } v })
+        {
+            return new PeerId(v);
+        }
+        // 兜底：用 gRPC 给的 peer 字符串（含 host:port）+ 调用唯一 id
+        return new PeerId($"{context.Peer}#{Guid.NewGuid():N}");
+    }
+
+    private void RaisePeerEvent(PeerId peer, PeerConnectionState state)
+    {
+        try
+        {
+            PeerConnectionChanged?.Invoke(this, new PeerConnectionEvent(peer, state));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PeerConnectionChanged handler threw for {Peer}", peer);
+        }
+    }
+
+    private sealed class PeerSession : IDisposable
+    {
+        public IServerStreamWriter<Frame> Response { get; }
+        public SemaphoreSlim WriteLock { get; } = new(1, 1);
+
+        public PeerSession(IServerStreamWriter<Frame> response) => Response = response;
+
+        public void Dispose() => WriteLock.Dispose();
+    }
+}

--- a/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransportOptions.cs
+++ b/src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransportOptions.cs
@@ -1,0 +1,23 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+namespace Skywalker.Transport.Grpc;
+
+/// <summary>
+/// <see cref="GrpcServerTransport"/> 的配置选项。
+/// </summary>
+public sealed class GrpcServerTransportOptions
+{
+    /// <summary>
+    /// 服务端从客户端 metadata 中读取 PeerId 的 header 名。
+    /// 如果客户端未提供，则使用 gRPC 的连接级唯一 ID（<c>connection-id:call-id</c>）兜底。
+    /// 默认 <c>x-skywalker-peer-id</c>。
+    /// </summary>
+    public string PeerIdMetadataKey { get; set; } = "x-skywalker-peer-id";
+
+    /// <summary>
+    /// 当向某 peer 发送消息时，若对应 stream 已断开是否抛 <see cref="TransportSendException"/>。
+    /// 默认 <c>true</c>。设为 <c>false</c> 则静默丢弃（用于 fire-and-forget 广播场景）。
+    /// </summary>
+    public bool ThrowOnUnknownPeer { get; set; } = true;
+}

--- a/tests/Skywalker.Transport.Grpc.Tests/GrpcServerTransportTests.cs
+++ b/tests/Skywalker.Transport.Grpc.Tests/GrpcServerTransportTests.cs
@@ -1,0 +1,229 @@
+// Licensed to the Gordon under one or more agreements.
+// Gordon licenses this file to you under the MIT license.
+
+using System.Net;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Skywalker.Transport.Grpc.Protocol;
+
+namespace Skywalker.Transport.Grpc.Tests;
+
+/// <summary>
+/// 验证 <see cref="GrpcServerTransport"/> + <see cref="BidiServiceImpl"/>。
+/// 测试本身扮演 gRPC client；real server 用受测的 transport。
+/// </summary>
+public class GrpcServerTransportTests
+{
+    /// <summary>多帧消息：client 一次性写出多帧，server 端 ReceiveAsync 拿到完整一条 TransportMessage。</summary>
+    [Fact]
+    public async Task ReceiveAsync_AssemblesMultiFrameMessageFromClient()
+    {
+        await using var fx = await ServerFixture.StartAsync();
+        await using var client = new TestBidiClient(fx.Address, peerId: "peer-A");
+
+        await client.SendAsync(new byte[][] { [0x01], [0x02, 0x02], [0x03, 0x03, 0x03] }, endOfMessage: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await foreach (var msg in fx.Transport.ReceiveAsync(cts.Token))
+        {
+            Assert.Equal(new PeerId("peer-A"), msg.From);
+            Assert.Equal(3, msg.Frames.Count);
+            Assert.Equal(new byte[] { 0x01 }, msg.Frames[0].ToArray());
+            Assert.Equal(new byte[] { 0x02, 0x02 }, msg.Frames[1].ToArray());
+            Assert.Equal(new byte[] { 0x03, 0x03, 0x03 }, msg.Frames[2].ToArray());
+            return;
+        }
+        Assert.Fail("Server transport did not produce a message.");
+    }
+
+    /// <summary>SendAsync(peer, ...): server 推一条多帧消息给指定 client。</summary>
+    [Fact]
+    public async Task SendAsync_DeliversMessageToTargetedPeer()
+    {
+        await using var fx = await ServerFixture.StartAsync();
+        await using var client = new TestBidiClient(fx.Address, peerId: "peer-X");
+
+        await WaitFor(() => fx.ConnectedPeers.Contains(new PeerId("peer-X")));
+
+        await fx.Transport.SendAsync(
+            new PeerId("peer-X"),
+            [(ReadOnlyMemory<byte>)new byte[] { 0xAA }, new byte[] { 0xBB }]);
+
+        var received = await client.ReceiveOneMessageAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(2, received.Count);
+        Assert.Equal(new byte[] { 0xAA }, received[0]);
+        Assert.Equal(new byte[] { 0xBB }, received[1]);
+    }
+
+    /// <summary>未注册的 peer：SendAsync 抛 <see cref="TransportSendException"/>。</summary>
+    [Fact]
+    public async Task SendAsync_UnknownPeer_Throws()
+    {
+        await using var fx = await ServerFixture.StartAsync();
+
+        await Assert.ThrowsAsync<TransportSendException>(async () =>
+            await fx.Transport.SendAsync(new PeerId("nope"), [(ReadOnlyMemory<byte>)new byte[] { 1 }]));
+    }
+
+    /// <summary>多 peer 隔离：不同 client 之间不会串扰。</summary>
+    [Fact]
+    public async Task MultiplePeers_AreIsolated()
+    {
+        await using var fx = await ServerFixture.StartAsync();
+        await using var clientA = new TestBidiClient(fx.Address, peerId: "A");
+        await using var clientB = new TestBidiClient(fx.Address, peerId: "B");
+
+        await WaitFor(() =>
+            fx.ConnectedPeers.Contains(new PeerId("A")) &&
+            fx.ConnectedPeers.Contains(new PeerId("B")));
+
+        await fx.Transport.SendAsync(new PeerId("A"), [(ReadOnlyMemory<byte>)new byte[] { 0xA1 }]);
+        await fx.Transport.SendAsync(new PeerId("B"), [(ReadOnlyMemory<byte>)new byte[] { 0xB1 }]);
+
+        var ra = await clientA.ReceiveOneMessageAsync(TimeSpan.FromSeconds(5));
+        var rb = await clientB.ReceiveOneMessageAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(new byte[] { 0xA1 }, ra[0]);
+        Assert.Equal(new byte[] { 0xB1 }, rb[0]);
+    }
+
+    /// <summary>
+    /// 铁律 #4：客户端断开 → server 触发 Disconnected 事件，且 peer 被移除。
+    /// </summary>
+    [Fact]
+    public async Task PeerConnectionChanged_FiresDisconnected_OnClientDisconnect()
+    {
+        await using var fx = await ServerFixture.StartAsync();
+        var client = new TestBidiClient(fx.Address, peerId: "ephemeral");
+
+        await WaitFor(() => fx.ConnectedPeers.Contains(new PeerId("ephemeral")));
+        await client.DisposeAsync();
+        await WaitFor(() => !fx.ConnectedPeers.Contains(new PeerId("ephemeral")));
+
+        Assert.Contains(fx.Events, e => e.Peer.Value == "ephemeral" && e.State == PeerConnectionState.Connected);
+        Assert.Contains(fx.Events, e => e.Peer.Value == "ephemeral" && e.State == PeerConnectionState.Disconnected);
+    }
+
+    private static async Task WaitFor(Func<bool> condition, double timeoutSec = 10)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(timeoutSec);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    /// <summary>启动一个真实 Kestrel + gRPC server，挂上受测 transport。</summary>
+    private sealed class ServerFixture : IAsyncDisposable
+    {
+        public WebApplication App { get; }
+        public GrpcServerTransport Transport { get; }
+        public Uri Address { get; }
+        public List<PeerConnectionEvent> Events { get; } = new();
+        public HashSet<PeerId> ConnectedPeers { get; } = new();
+
+        private ServerFixture(WebApplication app, GrpcServerTransport transport, Uri address)
+        {
+            App = app;
+            Transport = transport;
+            Address = address;
+            transport.PeerConnectionChanged += (_, e) =>
+            {
+                lock (Events)
+                {
+                    Events.Add(e);
+                    if (e.State == PeerConnectionState.Connected) ConnectedPeers.Add(e.Peer);
+                    else ConnectedPeers.Remove(e.Peer);
+                }
+            };
+        }
+
+        public static async Task<ServerFixture> StartAsync()
+        {
+            var builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(o =>
+            {
+                o.Listen(IPAddress.Loopback, 0, lo => lo.Protocols = HttpProtocols.Http2);
+            });
+            builder.Services.AddGrpc();
+            builder.Services.AddGrpcServerTransport("server-test");
+
+            var app = builder.Build();
+            app.MapGrpcService<BidiServiceImpl>();
+
+            await app.StartAsync().ConfigureAwait(false);
+
+            var address = new Uri(app.Services
+                .GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>()
+                .Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>()!
+                .Addresses.First());
+
+            var transport = app.Services.GetRequiredService<GrpcServerTransport>();
+            return new ServerFixture(app, transport, address);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await App.StopAsync().ConfigureAwait(false);
+            await App.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>测试用客户端：直接用生成的 BidiClient 调用 server。</summary>
+    private sealed class TestBidiClient : IAsyncDisposable
+    {
+        private readonly GrpcChannel _channel;
+        private readonly AsyncDuplexStreamingCall<Frame, Frame> _call;
+        private readonly CancellationTokenSource _cts = new();
+
+        public TestBidiClient(Uri serverAddress, string peerId)
+        {
+            _channel = GrpcChannel.ForAddress(serverAddress);
+            var client = new Bidi.BidiClient(_channel);
+            var headers = new Metadata { { "x-skywalker-peer-id", peerId } };
+            _call = client.Connect(new CallOptions(headers: headers, cancellationToken: _cts.Token));
+        }
+
+        public async Task SendAsync(byte[][] frames, bool endOfMessage)
+        {
+            for (var i = 0; i < frames.Length; i++)
+            {
+                await _call.RequestStream.WriteAsync(new Frame
+                {
+                    Payload = ByteString.CopyFrom(frames[i]),
+                    EndOfMessage = endOfMessage && i == frames.Length - 1,
+                }).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<List<byte[]>> ReceiveOneMessageAsync(TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var msg = new List<byte[]>();
+            await foreach (var frame in _call.ResponseStream.ReadAllAsync(cts.Token).ConfigureAwait(false))
+            {
+                msg.Add(frame.Payload.ToByteArray());
+                if (frame.EndOfMessage) return msg;
+            }
+            throw new TimeoutException("No message received within " + timeout);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { await _call.RequestStream.CompleteAsync().ConfigureAwait(false); } catch { }
+            try { _cts.Cancel(); } catch { }
+            try { _call.Dispose(); } catch { }
+            try { await _channel.ShutdownAsync().ConfigureAwait(false); } catch { }
+            _channel.Dispose();
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## 概要

`#203` Phase 1 server 端：在 `Skywalker.Transport.Grpc` 包中新增基于 gRPC bidi stream 的 **server-side `ITransport`** 实现。
配合已合并的 #206（client side）共同补完 v2 跨主机消息通道，可在不依赖 NetMQ 的前提下走标准 HTTPS/HTTP2。

> 原 PR #207 因 base 分支 (`feature/issue-203-transport-grpc`) 在 #206 squash-merge 后被删除而被 GitHub 自动关闭；本 PR 为 rebase 到 main 后重开。

## 变更

- `src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransportOptions.cs` — peer-id metadata 头名（默认 `x-skywalker-peer-id`）、未知 peer 是否抛错。
- `src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/GrpcServerTransport.cs` — 实现 `ITransport`：维护 `ConcurrentDictionary<PeerId, PeerSession>`，per-peer 写锁保证铁律 #3，`HandleConnectAsync` 是中央状态机。
- `src/Skywalker.Transport.Grpc/Skywalker/Transport/Grpc/BidiServiceImpl.cs` — 继承生成的 `Bidi.BidiBase`，把流的生命周期委托给 transport。
- `src/Skywalker.Transport.Grpc/Microsoft/Extensions/DependencyInjection/GrpcServerTransportServiceCollectionExtensions.cs` — `AddGrpcServerTransport(name, configure?)`。
- `tests/Skywalker.Transport.Grpc.Tests/GrpcServerTransportTests.cs` — 5 个集成测试，使用真实 Kestrel + 真实 gRPC client。
- `CHANGELOG.md` — Unreleased server-side 条目。

## Transport 铁律检查清单

- [x] **#1** 读循环（`HandleConnectAsync` 中的 `MoveNext` loop）只把组装好的 `TransportMessage` 写入 unbounded `Channel`，不调用任何业务回调。
- [x] **#2** `SendAsync` 单次写失败仅抛 `TransportSendException`，不会触发 `PeerConnectionChanged(Disconnected)`。
- [x] **#3** `cancellationToken` 仅在 pre-wire 阶段（等待 `WriteLock`）有效；一旦进入 `Response.WriteAsync`，**不传 ct**，避免 HTTP/2 RST_STREAM 把整个 stream 撕掉。
- [x] **#4** 唯一的断开判定来自 `HandleConnectAsync` 的 `try/finally`；任何路径都恰好触发一次 `Disconnected`。

## 测试结果

```
测试总数: 10  通过: 10  失败: 0  时长: ~0.8s
```

包含本次新增的 server-side 用例：

- `ReceiveAsync_AssemblesMultiFrameMessageFromClient`
- `SendAsync_DeliversMessageToTargetedPeer`
- `SendAsync_UnknownPeer_Throws`
- `MultiplePeers_AreIsolated`
- `PeerConnectionChanged_FiresDisconnected_OnClientDisconnect`

## 影响

- 解锁 Phase 3：`gaming-dotnet-sdk` 可以直接基于 `Skywalker.Messaging` + `GrpcServerTransport` 重写 Director/Channel。
- 不影响现有 NetMQ transport 用户；纯增量。
- 不引入新外部依赖（gRPC 包已在 #206 中加入）。

## 关联

- Closes (server-side portion of) #203
- Refs #201 (v2 NuGet 拆包总规划)
- Supersedes #207