### PR TITLE
chore: v2.0 preview publish + version strategy docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 讨论
-    url: https://github.com/L8CHAT/Skywalker/discussions
+    url: https://github.com/dengxuan/Skywalker/discussions
     about: 有问题想讨论？请使用 Discussions
 

--- a/.github/workflows/nupkg-publish.yml
+++ b/.github/workflows/nupkg-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/2.0
     tags:
       - "v*.*.*"
 
@@ -48,9 +49,23 @@ jobs:
             echo "version=$VERSION" >> "$GITHUB_ENV"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+          elif [[ $GITHUB_REF == refs/heads/release/2.0 ]]; then
+            # release/2.0 分支 → 发布 v2.0 preview 包
+            NEW_VERSION="2.0.0-preview.${{ github.run_number }}"
+
+            sed -i "s|<MajorVersion>.*</MajorVersion>|<MajorVersion>2</MajorVersion>|" $VERSION_FILE
+            sed -i "s|<MinorVersion>.*</MinorVersion>|<MinorVersion>0</MinorVersion>|" $VERSION_FILE
+            sed -i "s|<PatchVersion>.*</PatchVersion>|<PatchVersion>0</PatchVersion>|" $VERSION_FILE
+            sed -i "s|<PreReleaseVersionLabel>.*</PreReleaseVersionLabel>|<PreReleaseVersionLabel>preview</PreReleaseVersionLabel>|" $VERSION_FILE
+            sed -i "s|<PreReleaseVersionIteration>.*</PreReleaseVersionIteration>|<PreReleaseVersionIteration>${{ github.run_number }}</PreReleaseVersionIteration>|" $VERSION_FILE
+
+            echo "v2.0 preview: $NEW_VERSION"
+            echo "version=$NEW_VERSION" >> "$GITHUB_ENV"
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
           else
             # 如果是推送 main 分支，自动生成预发布版本
-            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            LATEST_TAG=$(git describe --tags --match "v1.*" --abbrev=0 2>/dev/null || echo "")
 
             if [[ -n "$LATEST_TAG" ]]; then
               # 存在 Tag，解析 Major.Minor.Patch
@@ -82,11 +97,12 @@ jobs:
           fi
 
       - name: Commit and push updated version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add eng/Versions.props
-          git diff --cached --quiet && echo "No changes to commit" || (git commit -m "chore: update version to ${{ env.version }}" && git push origin HEAD:main)
+          git diff --cached --quiet && echo "No changes to commit" || (git commit -m "chore: update version to ${{ env.version }}" && git push origin "HEAD:${{ github.ref_name }}")
 
   publish:
     needs: update-version
@@ -95,7 +111,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: main
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup .NET

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - dev
+      - release/2.0
   pull_request:
     branches:
       - main
       - dev
+      - release/2.0
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,35 @@
 
 ### PR 目标分支选择
 
-| 你想做的事 | 目标分支 |
-|---|---|
-| 修 v1.x bug、加小特性 | `main` |
-| 实现 v2.0 Source Generator 相关功能 | `release/2.0` |
-| v2.0 计划性文档 / 设计 | `release/2.0`（除非也对 v1.x 有用） |
-| 仓库元信息（CI、模板、许可证等） | `main`（会自动 forward-merge） |
+> ⚠️ **默认原则：新功能优先 target `release/2.0`**。`main` 已进入 v1.x 维护期，仅接受 bug fix / 铁律类修复 / 仓库元信息改动；任何新增功能性 API 都应该进 `release/2.0`，避免日后双版本双份维护。
+
+| 你想做的事 | 目标分支 | 备注 |
+|---|---|---|
+| v1.x 的 bug 修复 | `main` | 会被 forward-merge 自动带到 `release/2.0` |
+| v1.x 的安全/合规修补 | `main` | 同上 |
+| 铁律级底层修复（如 Transport 4 铁律） | `main` | 两个版本都要享受的修复 |
+| 仓库元信息（CI、issue 模板、许可证、README 等） | `main` | 自动 forward-merge |
+| **新功能 / 新模块（默认）** | **`release/2.0`** | 不再 backport 到 v1.x |
+| v2.0 Source Generator 相关实现 | `release/2.0` | Epic #182 |
+| v2.0 API 设计 / 迁移指南 | `release/2.0` | `docs/migration/v1-to-v2.md` |
+
+**决策树：**
+
+```
+是 bug 修复？
+├─ 是 → 影响 v1.x 已发布用户吗？
+│       ├─ 是 → target: main
+│       └─ 否 → target: release/2.0
+└─ 否（是新功能） → 默认 target: release/2.0
+          └─ 例外：明确承诺 backport 到 v1.x 的小增强（罕见，需维护者预先同意）→ target: main
+```
+
+### 版本生命周期
+
+| 版本 | 状态 | 策略 |
+|---|---|---|
+| **v1.x** | 维护期 | 只接受 bug fix / 安全修复；不再加新功能；v2.0 GA 后进入 **6 个月 LTS**（仅安全修复），之后 EOL |
+| **v2.0** | 开发中 | 在 `release/2.0` 迭代，每次 push 自动发 `2.0.0-preview.N` NuGet（见 `nupkg-publish.yml`），鼓励用户提前试用反馈；preview → rc → GA |
 
 ### 分支命名规范
 
@@ -99,7 +122,7 @@ cd Skywalker
 ### 3. 添加上游仓库
 
 ```bash
-git remote add upstream https://github.com/L8CHAT/Skywalker.git
+git remote add upstream https://github.com/dengxuan/Skywalker.git
 ```
 
 ### 4. 同步最新代码
@@ -264,7 +287,7 @@ BREAKING CHANGE: IRepository 接口签名已更改
 
 ```bash
 # 1. 克隆仓库
-git clone https://github.com/L8CHAT/Skywalker.git
+git clone https://github.com/dengxuan/Skywalker.git
 cd Skywalker
 
 # 2. 还原依赖
@@ -594,9 +617,9 @@ public class OrderAppService
 
 | 渠道 | 用途 |
 |------|------|
-| [Issues](https://github.com/L8CHAT/Skywalker/issues) | Bug 报告、功能请求 |
-| [Discussions](https://github.com/L8CHAT/Skywalker/discussions) | 问题讨论、使用帮助 |
-| [Pull Requests](https://github.com/L8CHAT/Skywalker/pulls) | 代码贡献 |
+| [Issues](https://github.com/dengxuan/Skywalker/issues) | Bug 报告、功能请求 |
+| [Discussions](https://github.com/dengxuan/Skywalker/discussions) | 问题讨论、使用帮助 |
+| [Pull Requests](https://github.com/dengxuan/Skywalker/pulls) | 代码贡献 |
 
 ### 提交 Issue 前
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skywalker
 
-[![Build Status](https://github.com/L8CHAT/Skywalker/actions/workflows/build.yml/badge.svg)](https://github.com/L8CHAT/Skywalker/actions)
+[![Tests](https://github.com/dengxuan/Skywalker/actions/workflows/test.yml/badge.svg)](https://github.com/dengxuan/Skywalker/actions/workflows/test.yml)
 [![NuGet](https://img.shields.io/nuget/v/Skywalker.Ddd.svg)](https://www.nuget.org/packages/Skywalker.Ddd)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)
@@ -487,8 +487,8 @@ Skywalker.Caching.Redis
 
 ## 📞 联系方式
 
-- **Issues**: [GitHub Issues](https://github.com/L8CHAT/Skywalker/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/L8CHAT/Skywalker/discussions)
+- **Issues**: [GitHub Issues](https://github.com/dengxuan/Skywalker/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/dengxuan/Skywalker/discussions)
 
 ## 📄 许可证
 


### PR DESCRIPTION
## 概要

按版本规划策略落地**低成本但高回报**的 3 项改动：

1. `release/2.0` 分支自动发布 `2.0.0-preview.N` NuGet（让 Gaming SDK / 业务项目可提前试用）
2. CONTRIBUTING 默认分支策略反转：**新功能默认 target `release/2.0`**，`main` 进入 v1.x 维护期
3. 清理陈旧 URL（仓库早期在 `L8CHAT` 组织，现在是 `dengxuan`）

## 1. `release/2.0` → preview 发布 (`nupkg-publish.yml`)

| 触发 | 版本 |
|---|---|
| `git tag vX.Y.Z` | `X.Y.Z`（正式发布） |
| push to `main` | `1.x.X-beta.N`（基于 `v1.*` tag 找 MAJOR.MINOR） |
| **push to `release/2.0`**（新） | **`2.0.0-preview.N`** |

变更点：
- `on.push.branches` 增加 `release/2.0`
- 版本脚本新增 `refs/heads/release/2.0` 分支处理
- `main` 分支的 tag 查找加了 `--match "v1.*"`，避免未来打出 `v2.0.0` 后 main 误读成 v2 beta
- `checkout ref` 从硬编码 `main` 改为 `${{ github.ref }}`
- `git push origin HEAD:main` 改为 `HEAD:\${{ github.ref_name }}`
- 版本回写步骤加了 `if: push && refs/heads/*` 守卫，避免 tag 触发时试图推 commit

## 2. CONTRIBUTING — 默认分支反转

**关键改动**：新功能默认 target `release/2.0`，不再是 `main`。配套：
- 添加决策树（bug 修？→ 影响已发布用户？）
- 添加 \"版本生命周期\" 小节：v1.x 在 v2.0 GA 后进入 6 个月 LTS（仅安全修复），之后 EOL
- 明确 forward-merge 只承担 main → release/2.0 方向

## 3. URL 清理

- README / CONTRIBUTING / ISSUE_TEMPLATE 中的 `L8CHAT/Skywalker` → `dengxuan/Skywalker`（5 处）
- README CI badge 原指向 `workflows/build.yml`（不存在）→ 改为真实的 `workflows/test.yml`
- `docs/modules/transport.md` 引用的 `L8CHAT/gaming-dotnet-sdk` / `gaming-go-sdk` 是**跨仓**引用，**保留不改**
- README 的 \`Copyright © 2024 L8CHAT\` **保留**（可能是品牌名，由维护者决定）

## 验证

- CI 本次运行本身就会验证 workflow 语法
- preview 发布的端到端验证留给本 PR 合并 + forward-merge 带到 release/2.0 后，release/2.0 下一次 push 自动触发