### PR TITLE
ci: skip Versions.props commit-back on release/2.0 preview builds

### DIFF
--- a/.github/workflows/nupkg-publish.yml
+++ b/.github/workflows/nupkg-publish.yml
@@ -96,13 +96,17 @@ jobs:
             echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           fi
 
+      # Only main writes Versions.props back — preview builds on release/2.0
+      # are ephemeral (run_number changes every run) and would spam commits
+      # plus create recurring forward-merge conflicts on Versions.props.
+      # The nupkg version is injected via /p:PackageVersion=... anyway.
       - name: Commit and push updated version
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add eng/Versions.props
-          git diff --cached --quiet && echo "No changes to commit" || (git commit -m "chore: update version to ${{ env.version }}" && git push origin "HEAD:${{ github.ref_name }}")
+          git diff --cached --quiet && echo "No changes to commit" || (git commit -m "chore: update version to ${{ env.version }}" && git push origin HEAD:main)
 
   publish:
     needs: update-version


### PR DESCRIPTION
## 问题

PR #210 把 \`release/2.0\` 加进 \`nupkg-publish.yml\` 后，每次 push 到 \`release/2.0\` 都会触发一次:

1. publish workflow 运行
2. 把 \`eng/Versions.props\` 改成 preview.N 然后 commit 回 release/2.0

第一次 run（预先发 \`2.0.0-preview.35\`）已经在 release/2.0 留下了一个 \`chore: update version to 2.0.0-preview.35\` 的额外 commit（SHA: \`9904b85e\`）。长远看这会造成两个问题：

1. **history 噪音翻倍**：release/2.0 每个真实 commit 后面都跟一个版本号回写 commit。
2. **forward-merge 冲突**：main 的 publish 写 \`<MajorVersion>1</MajorVersion>\` 到 Versions.props；release/2.0 的 publish 写 \`<MajorVersion>2</MajorVersion>\`。两边持续分叉，\`main → release/2.0\` 的 forward-merge 会周期性在 Versions.props 上冲突。

## 解决

**把 \"Commit and push updated version\" 步骤限定只在 \`main\` 上执行。**

\`\`\`diff
-  if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
\`\`\`

## 为什么安全

- **nupkg 输出不受影响**：pack 步骤是 \`/p:PackageVersion=2.0.0-preview.\${run_number}\`，显式注入，不读 Versions.props 内容。
- **Versions.props 内容不 load-bearing**：它在 release/2.0 上会保持从 main forward-merge 过来的 v1.x 值。虽然文件内容 \"不对\"，但没人读。
- **tag 发布依然工作**：tag 触发走另一个 \`if [[ \$GITHUB_REF == refs/tags/* ]]\` 分支，会更新 Versions.props 并被后续 publish 步骤使用 —— 但 tag 发布不经过 commit-and-push 步骤（它的 if: 条件 \`startsWith(... 'refs/heads/')\` 原本就过滤了 tag）。新 if: 条件同样过滤 tag。
- **main 的 1.x beta 行为不变**：保留原有 \`HEAD:main\` 推送。

## 清理（可选，不在本 PR 做）

release/2.0 上已经存在的那个 \`9904b85e chore: update version to 2.0.0-preview.35\` commit：
- 保留即可，只是历史噪音
- 或者在某个后续的 v2 工作 PR 里顺手 rebase 掉（不建议单独开 PR 只为 revert 一个 commit）