### PR TITLE
chore: migrate to MinVer for git-tag-based versioning

### DIFF
--- a/.github/workflows/nupkg-publish.yml
+++ b/.github/workflows/nupkg-publish.yml
@@ -1,5 +1,11 @@
 name: Publish NuGet Packages
 
+# Version is derived from git tags via MinVer at build time (see Directory.Build.props).
+#   - push `vX.Y.Z[-suffix]` tag        → publishes that exact version
+#   - push commits to main (above v1.*) → publishes 1.0.N-alpha.0.N
+#   - push commits to release/2.0       → publishes 2.0.0-preview.1.N
+# No manual version management in this workflow.
+
 on:
   push:
     branches:
@@ -9,114 +15,18 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:
-  update-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.set-version.outputs.version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0  # 确保可以获取完整的 Git 历史和 Tag
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Determine Version
-        id: set-version
-        run: |
-          VERSION_FILE="eng/Versions.props"
-
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            # 如果是推送 Tag，直接使用 Tag 版本
-            VERSION=${GITHUB_REF#refs/tags/v}
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
-
-            # 更新 Versions.props 确保文件中的版本号与 Tag 一致
-            sed -i "s|<MajorVersion>.*</MajorVersion>|<MajorVersion>$MAJOR</MajorVersion>|" $VERSION_FILE
-            sed -i "s|<MinorVersion>.*</MinorVersion>|<MinorVersion>$MINOR</MinorVersion>|" $VERSION_FILE
-            sed -i "s|<PatchVersion>.*</PatchVersion>|<PatchVersion>$PATCH</PatchVersion>|" $VERSION_FILE
-
-            echo "Triggered by tag: $VERSION"
-            echo "version=$VERSION" >> "$GITHUB_ENV"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-          elif [[ $GITHUB_REF == refs/heads/release/2.0 ]]; then
-            # release/2.0 分支 → 发布 v2.0 preview 包
-            NEW_VERSION="2.0.0-preview.${{ github.run_number }}"
-
-            sed -i "s|<MajorVersion>.*</MajorVersion>|<MajorVersion>2</MajorVersion>|" $VERSION_FILE
-            sed -i "s|<MinorVersion>.*</MinorVersion>|<MinorVersion>0</MinorVersion>|" $VERSION_FILE
-            sed -i "s|<PatchVersion>.*</PatchVersion>|<PatchVersion>0</PatchVersion>|" $VERSION_FILE
-            sed -i "s|<PreReleaseVersionLabel>.*</PreReleaseVersionLabel>|<PreReleaseVersionLabel>preview</PreReleaseVersionLabel>|" $VERSION_FILE
-            sed -i "s|<PreReleaseVersionIteration>.*</PreReleaseVersionIteration>|<PreReleaseVersionIteration>${{ github.run_number }}</PreReleaseVersionIteration>|" $VERSION_FILE
-
-            echo "v2.0 preview: $NEW_VERSION"
-            echo "version=$NEW_VERSION" >> "$GITHUB_ENV"
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-          else
-            # 如果是推送 main 分支，自动生成预发布版本
-            LATEST_TAG=$(git describe --tags --match "v1.*" --abbrev=0 2>/dev/null || echo "")
-
-            if [[ -n "$LATEST_TAG" ]]; then
-              # 存在 Tag，解析 Major.Minor.Patch
-              MAJOR=$(echo "$LATEST_TAG" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\1/')
-              MINOR=$(echo "$LATEST_TAG" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\2/')
-              PATCH=$(echo "$LATEST_TAG" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\3/')
-
-              # 递增 PATCH 版本
-              NEW_PATCH=$((PATCH + 1))
-              NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH-beta.${{ github.run_number }}"
-            else
-              # 如果没有 Tag，使用默认版本
-              MAJOR=1
-              MINOR=0
-              NEW_PATCH=0
-              NEW_VERSION="1.0.0-beta.${{ github.run_number }}"
-            fi
-
-            # 更新 Versions.props
-            sed -i "s|<MajorVersion>.*</MajorVersion>|<MajorVersion>$MAJOR</MajorVersion>|" $VERSION_FILE
-            sed -i "s|<MinorVersion>.*</MinorVersion>|<MinorVersion>$MINOR</MinorVersion>|" $VERSION_FILE
-            sed -i "s|<PatchVersion>.*</PatchVersion>|<PatchVersion>$NEW_PATCH</PatchVersion>|" $VERSION_FILE
-            sed -i "s|<PreReleaseVersionLabel>.*</PreReleaseVersionLabel>|<PreReleaseVersionLabel>beta</PreReleaseVersionLabel>|" $VERSION_FILE
-            sed -i "s|<PreReleaseVersionIteration>.*</PreReleaseVersionIteration>|<PreReleaseVersionIteration>1</PreReleaseVersionIteration>|" $VERSION_FILE
-
-            echo "New version: $NEW_VERSION"
-            echo "version=$NEW_VERSION" >> "$GITHUB_ENV"
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Only main writes Versions.props back — preview builds on release/2.0
-      # are ephemeral (run_number changes every run) and would spam commits
-      # plus create recurring forward-merge conflicts on Versions.props.
-      # The nupkg version is injected via /p:PackageVersion=... anyway.
-      - name: Commit and push updated version
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add eng/Versions.props
-          git diff --cached --quiet && echo "No changes to commit" || (git commit -m "chore: update version to ${{ env.version }}" && git push origin HEAD:main)
-
   publish:
-    needs: update-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          fetch-depth: 0
+          fetch-depth: 0  # MinVer needs full history + tags
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -127,7 +37,7 @@ jobs:
         run: dotnet restore Skywalker.sln
 
       - name: Build and pack
-        run: dotnet pack Skywalker.sln --configuration Release --output ./nupkgs /p:PackageVersion=${{ needs.update-version.outputs.version }}
+        run: dotnet pack Skywalker.sln --configuration Release --output ./nupkgs
 
       - name: Publish to GitHub Packages
         run: dotnet nuget push "./nupkgs/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --symbol-source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="$(MinVerVersion)" PrivateAssets="all" />
   </ItemGroup>
+
+  <!--
+    MinVer derives the package version from git tags.
+    - Exactly on a `v*` tag           → that version (e.g. v1.0.0 → 1.0.0)
+    - After a stable tag (e.g. v1.0.0) with N commits → 1.0.1-alpha.0.N
+    - After a pre-release tag (e.g. v2.0.0-preview.1) with N commits → 2.0.0-preview.1.N
+    CI publishes on every branch push; only tag pushes produce "clean" versions.
+  -->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringRoot)Versions.props" />
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,27 +1,9 @@
 <Project>
 
-  <PropertyGroup>
-    <!-- 文件版本号 -->
-    <MajorVersion>1</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <SdkBandVersion>1.0.0</SdkBandVersion>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
-    <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
-    <UsingToolXliff>false</UsingToolXliff>
-    <LastReleasedStableAssemblyVersion>$(AssemblyVersion)</LastReleasedStableAssemblyVersion>
-    <PackageVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</PackageVersion>
-    <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
-  </ItemGroup>
+  <!--
+    Project version is derived from git tags via MinVer (see Directory.Build.props).
+    Do NOT add MajorVersion / MinorVersion / PatchVersion / PackageVersion here.
+  -->
 
   <!-- ==================== 集中管理 NuGet 包版本 ==================== -->
 
@@ -42,6 +24,10 @@
     <MicrosoftCodeAnalysisCSharpVersion>4.8.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftSourceLinkVersion>8.0.0</MicrosoftSourceLinkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Build tooling">
+    <MinVerVersion>7.0.0</MinVerVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="System">


### PR DESCRIPTION
## 概要

把项目版本号的事实源从 \`eng/Versions.props\` 里手维护的 MAJOR/MINOR/PATCH 字段 + CI bash 脚本运行时拼版本号，**替换为 [MinVer](https://github.com/adamralph/minver)** —— 构建时根据最近的 git tag 自动推导版本。

关联动作：已经分别打了 \`v1.0.0\`（main HEAD）和 \`v2.0.0-preview.1\`（release/2.0 HEAD）两个 anchor tag，本 PR 合入后它们就是 MinVer 的基准。

## 迁移后版本规则

| git 状态 | 产出版本 |
|---|---|
| 正好在 \`v1.0.0\` tag | \`1.0.0\` |
| 正好在 \`v2.0.0-preview.1\` tag | \`2.0.0-preview.1\` |
| main，\`v1.0.0\` 之后 N 个 commit | \`1.0.1-alpha.0.N\` |
| release/2.0，\`v2.0.0-preview.1\` 之后 N 个 commit | \`2.0.0-preview.1.N\` |
| 打 \`v1.0.1-rc.1\` tag | \`1.0.1-rc.1\` |
| 打 \`v1.0.1\` tag | \`1.0.1\`（v1.x 首个补丁 GA） |

## 变更详情

### 1. \`Directory.Build.props\`

\`\`\`xml
<PackageReference Include=\"MinVer\" Version=\"\$(MinVerVersion)\" PrivateAssets=\"all\" />
<PropertyGroup>
  <MinVerTagPrefix>v</MinVerTagPrefix>
  <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
</PropertyGroup>
\`\`\`

### 2. \`eng/Versions.props\`

**删除**所有项目自身版本相关字段（16 行 → 注释 1 行）：

- \`MajorVersion\` / \`MinorVersion\` / \`PatchVersion\` / \`PackageVersion\` / \`ProductVersion\` / \`AssemblyVersion\`
- \`PreReleaseVersionLabel\` / \`PreReleaseVersionIteration\`
- \`SdkBandVersion\` / \`StabilizePackageVersion\` / \`DotNetFinalVersionKind\`
- \`UsingToolMicrosoftNetILLinkTasks\` / \`UsingToolIbcOptimization\` / \`UsingToolXliff\`
- \`LastReleasedStableAssemblyVersion\`
- \`<ProjectServicingConfiguration>\` ItemGroup

**保留**第三方 NuGet 包版本集中管理（MicrosoftExtensionsVersion / GrpcNetClientVersion / …），不受影响。**新增** \`MinVerVersion\` = \`7.0.0\`。

### 3. \`.github/workflows/nupkg-publish.yml\`

从 114 行 → 34 行：

- 删除整个 \`update-version\` job（bash 版本计算 + sed 改 Versions.props）
- 删除 \"Commit and push updated version\" 步骤（之前 PR #212 已把它限制只在 main；本 PR 把它彻底删除 —— 不再有任何 CI 回写 commit）
- publish job 加 \`fetch-depth: 0\`，让 MinVer 看见全部 tag
- pack 命令不再显式传 \`/p:PackageVersion=...\`，MinVer 在 build 时自动设置

## 本地验证

在 pre-PR main HEAD（即 v1.0.0 tag 所在 commit）上：

\`\`\`
\$ dotnet msbuild src/Skywalker.Extensions.Universal/... -getProperty:Version
{
  \"Properties\": {
    \"Version\": \"1.0.0\",
    \"PackageVersion\": \"1.0.0\"
  }
}
\`\`\`

## 合入后预期

- **本 PR 合入 main** → main HEAD 是 v1.0.0 之上的一个新 commit → 下一次 publish 产出 \`Skywalker.*.1.0.1-alpha.0.1.nupkg\`
- **forward-merge 到 release/2.0** → release/2.0 HEAD 是 v2.0.0-preview.1 之上的一个新 commit → 下一次 release/2.0 上的人类触发推送会产出 \`Skywalker.*.2.0.0-preview.1.N.nupkg\`

## 回滚方案

如果 MinVer 有问题，单独 revert 本 PR 即可 —— tag (\`v1.0.0\` / \`v2.0.0-preview.1\`) 保留，Versions.props 恢复手维护模式。