### PR TITLE
fix(ci): rename MinVerVersion → MinVerPackageVersion (MinVer output-property collision)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="$(MinVerVersion)" PrivateAssets="all" />
+    <!-- NOTE: do NOT use $(MinVerVersion) for the package version —
+         MinVerVersion is an MinVer OUTPUT property; pre-setting it
+         makes MinVer short-circuit with that value as the project version. -->
+    <PackageReference Include="MinVer" Version="$(MinVerPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Build tooling">
-    <MinVerVersion>7.0.0</MinVerVersion>
+    <MinVerPackageVersion>7.0.0</MinVerPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="System">


### PR DESCRIPTION
## Bug

PR #213 introduced MinVer but stored the MinVer tooling version in \`\$(MinVerVersion)\`:

\`\`\`xml
<PackageReference Include=\"MinVer\" Version=\"\$(MinVerVersion)\" ... />
<MinVerVersion>7.0.0</MinVerVersion>
\`\`\`

**\`MinVerVersion\` is MinVer's OWN output property** — the computed version. Pre-setting it tells MinVer \"version already known, short-circuit\"，so MinVer never computes from git tags. Every package published to \`main\` landed as **\`Skywalker.*.7.0.0\`** instead of the expected \`Skywalker.*.1.0.1-alpha.0.1\`.

See https://github.com/adamralph/minver#outputs — \`MinVerVersion\` is listed as an output.

## Fix

Rename the tooling version property:

| File | Before | After |
|---|---|---|
| \`eng/Versions.props\` | \`<MinVerVersion>7.0.0</MinVerVersion>\` | \`<MinVerPackageVersion>7.0.0</MinVerPackageVersion>\` |
| \`Directory.Build.props\` | \`Version=\"\$(MinVerVersion)\"\` | \`Version=\"\$(MinVerPackageVersion)\"\` |

Added an inline comment in Directory.Build.props warning future editors.

## Local verification

On current main HEAD (1 commit past v1.0.0):

\`\`\`
\$ dotnet pack src/Skywalker.Extensions.Universal/...
Successfully created 'Skywalker.Extensions.Universal.1.0.1-alpha.0.1.nupkg'  ✅
\`\`\`

## Cleanup — not in this PR

The wrongly-published \`Skywalker.*.7.0.0\` packages on GitHub Packages will be cleaned up separately via GitHub API (requires \`delete:packages\` scope). If left, they're confusing but not breaking: downstream who pin a reasonable range like \`[1.0.0,2.0.0)\` won't pull them.