### PR TITLE
ci: simplify forward-merge conflict path + add workflow_dispatch to publish

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -47,17 +47,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="auto/forward-merge-main-${{ github.run_id }}"
-          git checkout -b "$BRANCH" origin/release/2.0
-          git push origin "$BRANCH"
-
           EXISTING=$(gh pr list --base release/2.0 --head main --state open --json number --jq '.[0].number' || true)
-          if [ -z "$EXISTING" ]; then
-            gh pr create \
-              --base release/2.0 \
-              --head main \
-              --title "chore: forward-merge main into release/2.0 (conflicts)" \
-              --body "Automated forward-merge from \`main\` failed due to conflicts. Please resolve manually.\n\nTriggered by ${{ github.sha }}."
-          else
+          if [ -n "$EXISTING" ]; then
             echo "An open forward-merge PR already exists: #$EXISTING"
+            exit 0
           fi
+
+          gh pr create \
+            --base release/2.0 \
+            --head main \
+            --title "chore: forward-merge main into release/2.0 (conflicts)" \
+            --body "$(cat <<'BODY'
+          Automated forward-merge from `main` to `release/2.0` failed due to conflicts.
+
+          **How to resolve manually:**
+
+          ```bash
+          git fetch origin
+          git checkout release/2.0 && git pull --ff-only
+          git merge origin/main
+          # resolve conflicts, then:
+          git push origin release/2.0
+          ```
+
+          This PR will auto-close once you push the resolved merge commit
+          to `release/2.0` (GitHub detects that `main` is reachable from
+          `release/2.0` and closes the PR as \"merged\").
+          BODY
+          )"

--- a/.github/workflows/nupkg-publish.yml
+++ b/.github/workflows/nupkg-publish.yml
@@ -13,6 +13,10 @@ on:
       - release/2.0
     tags:
       - "v*.*.*"
+  # Manual re-publish: useful when GitHub's push-workflow de-dup skips
+  # a merge-commit push, or to force re-build from any historical tag.
+  # Usage: gh workflow run nupkg-publish.yml --ref <branch-or-tag>
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

CI 两处卫生改进：

### 1. `forward-merge.yml` — 删掉死代码

\"Open PR if merge has conflicts\" 步骤之前会：

\`\`\`bash
BRANCH=\"auto/forward-merge-main-\${run_id}\"
git checkout -b \"\$BRANCH\" origin/release/2.0
git push origin \"\$BRANCH\"              # ← 推空分支
gh pr create --head main ...              # ← 但 PR 根本没用它
\`\`\`

\`\$BRANCH\` 是干净的 release/2.0 副本（没在它上面尝试过合并），而 PR 用的是 \`--head main\`。分支纯粹是垃圾。证据：今天 repo 里散着几个无用的 \`auto/forward-merge-main-*\` 分支。

修复：**直接删除**创建分支那段；PR 仍然 \`--head main --base release/2.0\`（GitHub 能优雅处理这种"将 main 的 commit 带到 release/2.0\"的 PR，实际上 push release/2.0 让 main 可达时 PR 会被自动标记为 merged）。

同时改进冲突 PR 的 body：加上分步 runbook 和 \"推解决后 PR 自动关闭\" 的说明。

### 2. `nupkg-publish.yml` — 加 \`workflow_dispatch\`

场景：昨天 release/2.0 的 \`7375c68e\` merge commit 被 GitHub Actions 的 push-workflow dedup 跳过了（因为 parent 已经在 main 上被构建过）。结果是 release/2.0 的最新代码没有被发成 preview 包。

新增 \`workflow_dispatch\` trigger 提供 escape hatch：

\`\`\`bash
gh workflow run nupkg-publish.yml --ref release/2.0
\`\`\`

MinVer 基于当前 ref 的 git state 推版本，和正常 push 触发走完全相同的构建路径。

## 顺带清理（合并后手动做）

本 PR 合并后，repo 里还残留两个无用的 \`auto/forward-merge-main-*\` 分支（由旧版 workflow 创建）：

- \`auto/forward-merge-main-24840301465\`
- \`auto/forward-merge-main-24840615832\`

手动清理：
\`\`\`bash
git push origin --delete auto/forward-merge-main-24840301465
git push origin --delete auto/forward-merge-main-24840615832
\`\`\`