### PR TITLE
docs(release): align CHANGELOG + roadmap with v1.0.0 / v2.0.0-preview.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,6 @@
 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
-## [2.0.0] - 规划中
-
-v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
-
-- 全面 Source Generator 化：消灭运行时反射、消灭 `Reflection.Emit`。
-- 移除 `Castle.Core` 依赖（~600 KB）。
-- NativeAOT publish 零警告。
-- `AddSkywalker()` 一行启动，零样板注册。
-
-设计与规划文档：
-
-- [`docs/architecture/v2.0-roadmap.md`](docs/architecture/v2.0-roadmap.md)
-- [`docs/architecture/source-generators-spec.md`](docs/architecture/source-generators-spec.md)
-- [`docs/architecture/source-generators-quality.md`](docs/architecture/source-generators-quality.md)
-
-发版策略：`main` → `2.0.0-alpha.x` → `2.0.0-preview.x` → `2.0.0-rc.x` → `2.0.0`。
-每个阶段最低浸泡 2 周，详见质量规范。
-
 ## [Unreleased]
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)
@@ -32,23 +14,80 @@ v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
     - Go 实现：[dengxuan/vertex-go](https://github.com/dengxuan/vertex-go)（module `github.com/dengxuan/vertex-go`）
     - Wire 规范：[dengxuan/Vertex](https://github.com/dengxuan/Vertex)
 - 原因：Messaging/Transport 本质是**跨语言通信基础设施**，与 Skywalker 的 .NET DDD 框架定位不同步；强行捆绑导致 Go 等语言场景无法对等接入。详见 [messaging-spin-out.md](docs/architecture/messaging-spin-out.md)。
-- **迁移**：把 `using Skywalker.Messaging;` / `using Skywalker.Transport;` 改为 `using Vertex.Messaging;` / `using Vertex.Transport;`；`<PackageReference Include="Skywalker.Messaging" />` 改为 `<PackageReference Include="Vertex.Messaging" />` 等。API 语义（`IMessageBus`、`IRpcClient`、`ITransport`、4 条铁律）保持不变。详见 [docs/migration/v1-to-v2.md § 5](docs/migration/v1-to-v2.md)（release/2.0 分支）。
+- **迁移**：把 `using Skywalker.Messaging;` / `using Skywalker.Transport;` 改为 `using Vertex.Messaging;` / `using Vertex.Transport;`；`<PackageReference Include="Skywalker.Messaging" />` 改为 `<PackageReference Include="Vertex.Messaging" />` 等。API 语义（`IMessageBus`、`IRpcClient`、`ITransport`、4 条铁律）保持不变。
 - **已发布的 `Skywalker.Messaging.1.0.0` 等 NuGet 包保留不动**，老用户可继续 pin 至 `1.0.0`；不会有 `Skywalker.Messaging.1.0.1+` 继续发布。需要新功能 / bug fix 时请升级到 `Vertex.*`。
 - _后续_ 可能发布 `Skywalker.Messaging.1.0.1` 等带 `[TypeForwardedTo]` 的桥接包，指向 `Vertex.*`。是否发布、何时发布视下游实际迁移情况而定；目前**不**自动发。
 
-### Removed
+### Changed
 
-- **BREAKING**：移除 `Skywalker.Ddd.Application` 对 [AutoMapper](https://github.com/AutoMapper/AutoMapper) 的依赖（AutoMapper 自 v15 起转向商业授权）。
-- 删除 `SkywalkerProfile`。
-- 移除 `ApplicationService` 的 `IMapper Mapper` 属性与构造函数参数。
-- 移除 `eng/Versions.props` 中的 `AutoMapperVersion`。
+- 迁移到 [MinVer](https://github.com/adamralph/minver) 由 git tag 驱动版本号 (#213, #215)。
+- 新增权威的版本策略文档 [docs/versioning.md](docs/versioning.md)，从 CONTRIBUTING 链接 (#216)。
+- 简化 forward-merge 冲突处理路径，发布工作流增加 `workflow_dispatch` 触发 (#217)。
+- CONTRIBUTING / 架构文档同步反映 Messaging/Transport → Vertex 的 spin-out (#218, #219, #221)。
+
+## [2.0.0-preview.1] - 2026-04-23
+
+v2.0 发版通道的第一个标记 tag。基于 v1.0.0 stable，从 `release/2.0` 分支开辟独立发布通道，用于后续 v2.0 全面 Source Generator 化迭代的 preview / rc 浸泡测试。包内容与 v1.0.0 几乎一致，差异仅在版本号体系与新增的迁移指南骨架。
+
+### Added
+
+- v1.x → v2.0 迁移指南骨架 [docs/migration/v1-to-v2.md](https://github.com/dengxuan/Skywalker/blob/release/2.0/docs/migration/v1-to-v2.md)（仅在 `release/2.0` 分支）(#211)。
 
 ### Changed
 
-- `ApplicationService` 现在为无参基类，业务派生类请自行注入所需服务。
-- 全部文档（README、CONTRIBUTING、`docs/`、`samples/`）的对象映射示例改为使用 [Riok.Mapperly](https://github.com/riok/mapperly) 源生成器。
+- 版本号体系切换为 `2.0.0-preview.x`（MinVer 自动）。
+- CI 跳过 `Versions.props` 回写以避免在 `release/2.0` 上意外触发 main 同步循环 (#212)。
 
-### Migration Guide
+## [1.0.0] - 2026-04-23
+
+Skywalker 首个 stable 版本，提供完整的 .NET 8 DDD 应用开发框架。
+
+### Added — 核心框架
+
+- DDD 基础抽象与 EF Core 集成（`Skywalker.Ddd`、`Skywalker.Ddd.EntityFrameworkCore`）
+- 应用服务、Repository、UnitOfWork、领域事件、值对象、聚合根、规约
+- 多租户支持、审计日志、对象映射约定、数据过滤
+
+### Added — 模块
+
+- `Skywalker.Permissions.*`：权限注册 / 验证 / 服务端授权数据同步（issues #9-#16）
+- `Skywalker.Settings.*` / `Skywalker.Localization` / `Skywalker.Validation`
+- `Skywalker.Security` / `Skywalker.AspNetCore`
+- `Skywalker.Extensions.*`：`DependencyInjection`、`DynamicProxies`、`Universal`、`Linq` 等
+
+### Added — Source Generator（v1 阶段，反射混合期）
+
+- `Skywalker.SourceGenerators`：模块化自动注册（`SkywalkerModuleAttribute` + 程序集扫描，issues #120-#126）
+- `Skywalker.Extensions.DynamicProxies.SourceGenerators`：拦截器静态代理生成
+- `AddSkywalker()` / `ISkywalkerBuilder` 一站式注册入口（Console / Web 统一）
+
+### Added — Messaging & Transport（已于 [Unreleased] spin-out 至 Vertex）
+
+- `Skywalker.Messaging.Abstractions` / `Skywalker.Messaging`：bidi 消息内核（`IMessageBus` / `IRpcClient` / `IRpcHandler<TReq,TRes>`）(#193)
+- `Skywalker.Transport.Abstractions` / `Skywalker.Transport.NetMq`：传输层抽象 + ZeroMQ 实现 (#193)
+- `Skywalker.Transport.Grpc` / `Skywalker.Transport.Grpc.Server`：gRPC bidi 传输实现 (#203, #206, #208)
+- 4 条铁律协议约束并通过 XML doc 在 `ITransport.SendAsync` 上固化 CT 契约 (#202, #205)
+  1. read loop 只内联路由 Ack；handler 异步派发
+  2. 单条 reply 发送失败 ≠ 断连
+  3. write 拿到锁后必须不被 CT 中断（CT 只用于「上线前」取消）
+  4. 唯一断连源是 read loop 的 `Recv()` / `MoveNext()` 错误
+
+### Changed — BREAKING（v0.x 用户）
+
+- **移除 `Skywalker.Ddd.Application` 对 [AutoMapper](https://github.com/AutoMapper/AutoMapper) 的依赖**（AutoMapper 自 v15 起转为商业授权）(#181)。
+  - 删除 `SkywalkerProfile`。
+  - 移除 `ApplicationService` 的 `IMapper Mapper` 属性与构造函数参数。
+  - 移除 `eng/Versions.props` 中的 `AutoMapperVersion`。
+- `ApplicationService` 改为无参基类，业务派生类自行注入所需服务。
+- 全部文档示例改为使用 [Riok.Mapperly](https://github.com/riok/mapperly) 源生成器。
+
+### Documentation
+
+- 完整 README / CONTRIBUTING / API / 使用指南 / 示例项目（issues #17-#21, #66）
+- 架构设计文档体系（[docs/architecture/](docs/architecture/)）
+- v2.0 Source Generator 路线图与规范（[v2.0-roadmap.md](docs/architecture/v2.0-roadmap.md)、[source-generators-spec.md](docs/architecture/source-generators-spec.md)、[source-generators-quality.md](docs/architecture/source-generators-quality.md)）(#183)
+
+### v0.x → v1.0 Migration Guide（AutoMapper → Mapperly）
 
 派生 `ApplicationService` 的业务代码需要按以下步骤迁移：
 
@@ -92,8 +131,32 @@ v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
 
 5. **移除 DI 中对 AutoMapper 的注册**（如有）：删除 `services.AddAutoMapper(...)`。
 
-### Why
+理由：
 
 - AutoMapper 自 v15 起转向商业授权，框架不应将商业许可成本传递给使用者。
 - Mapperly 是 MIT 许可的源生成器，编译期生成映射代码，零运行时反射开销，对原生 AOT 友好，重构时编译器即可发现字段不匹配。
 - 框架原本就未在 DI 容器中注册 AutoMapper，派生 `ApplicationService` 的服务实际无法解析 `IMapper`，移除此依赖同时修复该潜在缺陷。
+
+---
+
+## v2.0 Roadmap
+
+v2.0 是 Skywalker 的差异化战役，定位 **小、快、易用**：
+
+- 全面 Source Generator 化：消灭运行时反射、消灭 `Reflection.Emit`。
+- 移除 `Castle.Core` 依赖（~600 KB）。
+- NativeAOT publish 零警告。
+- `AddSkywalker()` 一行启动，零样板注册。
+- Messaging/Transport 已 spin-out 到 [Vertex](https://github.com/dengxuan/Vertex) 独立项目。
+
+设计与规划文档：
+
+- [`docs/architecture/v2.0-roadmap.md`](docs/architecture/v2.0-roadmap.md)
+- [`docs/architecture/source-generators-spec.md`](docs/architecture/source-generators-spec.md)
+- [`docs/architecture/source-generators-quality.md`](docs/architecture/source-generators-quality.md)
+
+发版策略：`release/2.0` → `2.0.0-preview.x` → `2.0.0-rc.x` → `2.0.0`，每阶段最低浸泡 2 周，详见 [versioning.md](docs/versioning.md)。
+
+[Unreleased]: https://github.com/dengxuan/Skywalker/compare/v2.0.0-preview.1...HEAD
+[2.0.0-preview.1]: https://github.com/dengxuan/Skywalker/compare/v1.0.0...v2.0.0-preview.1
+[1.0.0]: https://github.com/dengxuan/Skywalker/releases/tag/v1.0.0

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -1,12 +1,19 @@
 # Skywalker v2.0 路线图
 
-> 状态：**草案 (Draft)**　|　目标版本：**v2.0.0**　|　最后更新：2026-04-21
+> 状态：**进行中 (In Progress)**　|　目标版本：**v2.0.0**　|　最后更新：2026-04-25
+
+## 0. 当前进度
+
+- ✅ [`v1.0.0`](https://github.com/dengxuan/Skywalker/releases/tag/v1.0.0) stable 已发布（2026-04-23）
+- ✅ [`v2.0.0-preview.1`](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1) 通道开通（2026-04-23），用于后续 SG 化迭代的浸泡测试
+- ✅ Messaging/Transport 已 spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex)（已合入 main）
+- ⏳ EF Repository SG / DynamicProxy SG / DI 自动注册 SG 待启动
 
 ## 1. 定位 (Positioning)
 
 Skywalker v2.0 的差异化关键词：**小、快、易用**。
 
-- **小**：移除 Castle.Core (~600 KB) 等重量级运行时依赖。
+- **小**：移除 Castle.Core (~600 KB) 等重量级运行时依赖；Messaging/Transport 跨语言基础设施 spin-out 到 Vertex，让 Skywalker 回归 .NET DDD 框架本职。
 - **快**：消灭启动期反射；消灭运行时 IL Emit；NativeAOT 一等公民。
 - **易用**：`AddSkywalker()` 一行启动；零样板注册；约定优于配置。
 
@@ -27,47 +34,54 @@ Slogan:
 
 ### 3.1 In Scope（v2.0 必做）
 
-| # | 项目 | 现状 | v2.0 目标 |
-|---|---|---|---|
-| 1 | EF Repository 注册 | 反射 `MakeGenericType` | SG 编译期生成 |
-| 2 | DynamicProxy 拦截器 | Castle.DynamicProxy IL Emit | SG 编译期生成静态代理 |
-| 3 | DI 服务注册 | 部分手动 | `[Service]` / `[ApplicationService]` 标注 + SG |
-| 4 | EventBus Handler 发现 | 反射扫程序集 | SG 编译期收集 |
-| 5 | 移除 Castle.Core 依赖 | 强依赖 | 完全移除 |
-| 6 | NativeAOT publish 零警告 | ❌ | ✅ |
-| 7 | `AddSkywalker()` 统一入口 | 多个 `AddXxx()` | 一行启动 |
+| # | 项目 | 现状 | v2.0 目标 | 状态 |
+|---|---|---|---|---|
+| 1 | EF Repository 注册 | 反射 `MakeGenericType` | SG 编译期生成 | ⏳ |
+| 2 | DynamicProxy 拦截器 | Castle.DynamicProxy IL Emit | SG 编译期生成静态代理 | ⏳ |
+| 3 | DI 服务注册 | 部分手动 | `[Service]` / `[ApplicationService]` 标注 + SG | ⏳ |
+| 4 | EventBus Handler 发现 | 反射扫程序集 | SG 编译期收集 | ⏳ |
+| 5 | 移除 Castle.Core 依赖 | 强依赖 | 完全移除 | ⏳ |
+| 6 | NativeAOT publish 零警告 | ❌ | ✅ | ⏳ |
+| 7 | `AddSkywalker()` 统一入口 | 多个 `AddXxx()` | 一行启动 | 🟡 部分（v1.0 已做基础） |
+| 8 | **AutoMapper → Mapperly** | AutoMapper（v15+ 商业授权） | 文档/示例迁移到 Mapperly，框架解除依赖 | ✅ 已完成（v1.0.0，#181） |
+| 9 | **Messaging/Transport spin-out** | 内置在 Skywalker 仓 | 迁出至独立项目 [Vertex](https://github.com/dengxuan/Vertex)（polyrepo + Vertex.* 命名） | ✅ 已完成（main，#218/#219/#221） |
 
 ### 3.2 Stretch Goal（v2.0 力争）
 
 | # | 项目 | 价值 |
 |---|---|---|
-| 8 | Permission 强类型 SG | 编译期生成权限常量类 |
-| 9 | Localization Key 强类型 SG | 编译期生成强类型 Key 访问器 |
-| 10 | Settings 强类型 SG | 编译期生成强类型 Settings 访问器 |
-| 11 | Roslyn Code Fix 迁移工具 | 一键迁移 v1.x → v2.0 |
+| 10 | Permission 强类型 SG | 编译期生成权限常量类 |
+| 11 | Localization Key 强类型 SG | 编译期生成强类型 Key 访问器 |
+| 12 | Settings 强类型 SG | 编译期生成强类型 Settings 访问器 |
+| 13 | Roslyn Code Fix 迁移工具 | 一键迁移 v1.x → v2.0 |
 
 ### 3.3 Out of Scope（v2.0 不做）
 
 - 多租户系统的全面重写（保持 v1.x 现状）
 - 审计日志、后台任务模块（v2.x 后续）
 - ABP Commercial 等同的高级模块
+- Messaging / Transport 演进——已转交 Vertex 项目
 
 ## 4. 阶段划分
 
-### Sprint 0（基础设施）—— 1 周
+> 实际进度：v1.0.0 stable + v2.0.0-preview.1 通道已开（2026-04-23）。原"Sprint 0 必须先于 Sprint 1"的强约束因为 In Scope #8/#9 两项已在 v1.0 期间完成而部分提前；Sprint 0 的 SG 质量基础设施仍是 SG 真正落地前的硬门槛。
+
+### Sprint 0（基础设施）—— 截至 2026-05-12
 
 发版前的"质量地基"。**绝不直接开始写 SG**，先把以下到位：
 
-- [ ] `tests/Skywalker.SourceGenerators.Tests/` 测试项目
+- [ ] `tests/Skywalker.SourceGenerators.Tests/` 测试项目（#185）
 - [ ] 引入 `Verify.SourceGenerators` + `Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing`
 - [ ] `GeneratorTestHelper`（封装 driver 创建、引用集合、输出收集）
-- [ ] `tests/SourceGenerators/EDGE_CASES.md` 边界场景清单
-- [ ] `Microsoft.CodeAnalysis.PublicApiAnalyzers` 接入
-- [ ] CI workflow：build → unit test → snapshot → samples → AOT publish 全链路
-- [ ] `samples/` 矩阵骨架（8 个项目）
-- [ ] `docs/diagnostics/` 诊断码索引页骨架
+- [ ] CI workflow `sg-quality.yml`：build → unit test → snapshot → samples → AOT publish 全链路（#186）
+- [ ] `samples/` 矩阵骨架（8 个项目，#187）
+- [ ] `Microsoft.CodeAnalysis.PublicApiAnalyzers` 接入（#188）
+- [ ] `tests/SourceGenerators/EDGE_CASES.md` 边界场景清单（#189）
+- [ ] `docs/diagnostics/` 诊断码索引页骨架（#190）
+- [ ] `Generator Common` 库 + `dotnet new` 模板（#191）
 
 输出物：可以直接套用的 SG 开发流程。
+预期产物 tag：`2.0.0-preview.2`（仅含质量基础设施）。
 
 ### Sprint 1（EF Repository SG）—— 2 周
 
@@ -78,8 +92,8 @@ Slogan:
 - [ ] ≥ 30 个 snapshot 测试
 - [ ] ≥ 5 个相关 sample 项目
 - [ ] ≥ 5 个 SKYxxxx diagnostic + 文档页
-- [ ] 发 `2.0.0-alpha.1`，邀请 ≥ 3 个种子用户试用
-- [ ] 浸泡 ≥ 2 周无 P0/P1，进入 preview
+- [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用
+- [ ] 浸泡 ≥ 2 周无 P0/P1，进入下一 sprint
 
 里程碑：**EF 模块零反射**。
 
@@ -87,7 +101,7 @@ Slogan:
 
 v2.0 核心战役。
 
-- [ ] `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目
+- [ ] `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目（替换 v1 阶段的混合实现）
 - [ ] 编译期生成静态代理类
 - [ ] 移除 `Castle.Core` 依赖
 - [ ] `[Intercept<T>]` 强类型拦截器 API
@@ -100,36 +114,35 @@ v2.0 核心战役。
 
 - [ ] `[Service]` / `[ApplicationService]` / `[Repository]` / `[EventHandler]` 标注
 - [ ] 模块入口 SG 生成 `__SkywalkerModuleInitializer__`
-- [ ] `AddSkywalker()` 统一入口
+- [ ] `AddSkywalker()` 统一入口收口
 - [ ] 命名约定 fallback（`*AppService` 等）
 
 里程碑：**Program.cs 缩减到 2 行**。
 
 ### Sprint 4（Stretch Goals）—— 视情况 1-3 周
 
-按优先级挑做：Permission / Localization / Settings 强类型 SG。
+按优先级挑做：Permission / Localization / Settings 强类型 SG、Roslyn Code Fix。
 
-### Sprint 5（发版）—— 4 周
+### Sprint 5（rc + stable）—— 4 周
 
 - [ ] 全部 sample 全绿
 - [ ] AOT publish 零警告
 - [ ] Public API 锁定（`PublicAPI.Shipped.txt`）
 - [ ] 文档完整：每个 attribute 有示例，每个 SKYxxxx 有诊断页
-- [ ] `2.0.0-preview.1` → 浸泡 ≥ 2 周
 - [ ] `2.0.0-rc.1` → 浸泡 ≥ 2 周
 - [ ] `2.0.0` 正式发布
-- [ ] v1.x → v2.0 迁移指南
+- [ ] v1.x → v2.0 迁移指南正式版（[`docs/migration/v1-to-v2.md`](https://github.com/dengxuan/Skywalker/blob/release/2.0/docs/migration/v1-to-v2.md) 在 release/2.0 分支已起草）
 
 ## 5. 发版通道
 
 ```
-main 提交              → 自动发 -alpha 包到 GitHub Packages
-打 v2.0-preview tag    → 发 -preview 包到 NuGet（≥ 2 周浸泡）
-打 v2.0-rc tag         → 发 -rc 包（≥ 2 周浸泡）
-打 v2.0 tag            → 发 stable 到 NuGet
+release/2.0 提交       → MinVer 自动生成 -preview.x 包
+打 v2.0.0-preview tag  → 发 -preview 到 NuGet（≥ 2 周浸泡）
+打 v2.0.0-rc tag       → 发 -rc 包（≥ 2 周浸泡）
+打 v2.0.0 tag          → 发 stable 到 NuGet
 ```
 
-**严禁** main → 直接 stable。每个阶段最低浸泡 2 周。
+**严禁** main → 直接 stable。每个阶段最低浸泡 2 周。详见 [versioning.md](../versioning.md)。
 
 ## 6. Stable 发版准入清单
 
@@ -139,16 +152,18 @@ main 提交              → 自动发 -alpha 包到 GitHub Packages
 
 v1.x → v2.0 的破坏性变更：
 
-| # | 变更 | 影响 | 迁移方案 |
-|---|---|---|---|
-| 1 | 移除 `Castle.Core` | 直接使用 Castle API 的代码 | 用 `[Intercept<T>]` |
-| 2 | `IInterceptable` 标注 → SG 标注 | 实现该接口的服务 | 加 `partial`，标 `[ApplicationService]` |
-| 3 | `AddInterceptedServices()` 删除 | Program.cs | 改用 `AddSkywalker()` |
-| 4 | AppService 无需继承基类 | （无强制破坏，向后兼容） | 可选迁移 |
-| 5 | EF Repository 注册改为 SG | （API 不变，行为等价） | 透明 |
-| 6 | 服务类型必须 `partial` | 标注的服务 | 加 `partial` 关键字 |
+| # | 变更 | 影响 | 迁移方案 | 状态 |
+|---|---|---|---|---|
+| 1 | 移除 `Castle.Core` | 直接使用 Castle API 的代码 | 用 `[Intercept<T>]` | 待 Sprint 2 |
+| 2 | `IInterceptable` 标注 → SG 标注 | 实现该接口的服务 | 加 `partial`，标 `[ApplicationService]` | 待 Sprint 2/3 |
+| 3 | `AddInterceptedServices()` 删除 | Program.cs | 改用 `AddSkywalker()` | 待 Sprint 3 |
+| 4 | AppService 无需继承基类 | （无强制破坏，向后兼容） | 可选迁移 | 待 Sprint 3 |
+| 5 | EF Repository 注册改为 SG | （API 不变，行为等价） | 透明 | 待 Sprint 1 |
+| 6 | 服务类型必须 `partial` | 标注的服务 | 加 `partial` 关键字 | 待 Sprint 3 |
+| 7 | **`Skywalker.Messaging.*` / `Skywalker.Transport.*` 移除** | 使用消息/传输 API 的代码 | 改用 `Vertex.Messaging` / `Vertex.Transport`（API 语义不变，4 条铁律保留） | ✅ 已完成（main） |
+| 8 | **AutoMapper 依赖移除** | 派生 `ApplicationService` 用 `Mapper` 的代码 | 改用 [Riok.Mapperly](https://github.com/riok/mapperly) | ✅ 已完成（v1.0.0） |
 
-完整迁移指南随 v2.0 stable 发布。
+完整迁移指南随 v2.0 stable 发布；草稿见 [`docs/migration/v1-to-v2.md`](https://github.com/dengxuan/Skywalker/blob/release/2.0/docs/migration/v1-to-v2.md)（release/2.0 分支）。
 
 ## 8. 风险登记
 
@@ -159,6 +174,7 @@ v1.x → v2.0 的破坏性变更：
 | 浸泡期种子用户不足 | 中 | 中 | 主动社区邀请；自有项目作为种子 1 |
 | Castle 老用户拒绝迁移 | 低 | 中 | v2.0 提供 1 个 minor 的 `[Obsolete]` 兼容层 |
 | 跨程序集 SG 信息丢失 | 中 | 高 | 模块入口生成 `[ModuleInitializer]` 自动挂载 |
+| Vertex 与 Skywalker 版本节奏失配 | 中 | 中 | Skywalker 不强 pin Vertex.*，由用户工程自选；docs 给出推荐组合 |
 
 ## 9. 决策记录
 
@@ -168,3 +184,7 @@ v1.x → v2.0 的破坏性变更：
 | 2026-04-21 | 不再"抄 ABP"，定位"小快易用" | 差异化战略 |
 | 2026-04-21 | Sprint 0 必须先于 Sprint 1 | 质量基础设施优先 |
 | 2026-04-21 | 发版强制走 alpha → preview → rc → stable | 浸泡 ≥ 2 周/阶段 |
+| 2026-04-23 | v1.0.0 stable 发布 + 开 v2.0.0-preview.1 通道 | 在 SG 主体启动前先稳一道版本基线 |
+| 2026-04-23 | 移除 AutoMapper 依赖（在 v1.0 完成而非延到 v2.0） | AutoMapper v15 商业授权，不能拖延 |
+| 2026-04-25 | Messaging/Transport spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex) | 跨语言通信基础设施定位与 .NET DDD 框架不同步；polyrepo + `Vertex.*` 命名 |
+| 2026-04-25 | 取消 alpha 通道，统一从 preview 起步 | release/2.0 + MinVer + git tag 直接驱动 preview/rc/stable，简化流程 |


### PR DESCRIPTION
## Summary

> Note: 本 PR 原本还含项目移除提交，rebase 后已被 #222 等价合并；现仅剩文档对齐这一个 commit。

CHANGELOG 之前一直停留在 \`[Unreleased]\` + \`[2.0.0] - 规划中\`，与已打的 \`v1.0.0\` / \`v2.0.0-preview.1\` 两个 tag 完全脱节；v2.0 路线图也未把 v1.0 期间已经完成的 AutoMapper 移除和 Messaging spin-out 写进 In Scope。

- **CHANGELOG.md** 新增 \`[1.0.0] - 2026-04-23\` 与 \`[2.0.0-preview.1] - 2026-04-23\` 两节，把原 \`[Unreleased]\` 中已发部分（AutoMapper 移除迁移指南等）下沉到 \`[1.0.0]\`。\`[Unreleased]\` 仅保留 main 当前真实未发布内容（Vertex spin-out / MinVer / versioning.md / forward-merge 简化）。底部补 compare 链接。
- **docs/architecture/v2.0-roadmap.md** 增 §0 当前进度；In Scope 表加入 #8 AutoMapper→Mapperly ✅ 与 #9 Messaging spin-out ✅；Breaking Changes 表加状态列；Sprint 0 截止从 2026-04-28 顺延到 2026-05-12；新增 4 条 2026-04-23/25 决策记录。

## 关联

- 同步发布的 GitHub Release：[v1.0.0](https://github.com/dengxuan/Skywalker/releases/tag/v1.0.0) / [v2.0.0-preview.1](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1)
- Epic #201 已更新现状盘点反映 Messaging/Transport spin-out 完成
- 配套已合：#222（移除 Skywalker.Messaging/Transport 项目本体）

## Test plan

- [ ] CHANGELOG 渲染检查：\`[1.0.0]\` / \`[2.0.0-preview.1]\` / \`[Unreleased]\` 三节齐全；底部 compare 链接可点击
- [ ] roadmap §0 显示当前进度三项 ✅；§3.1 In Scope 表 #8/#9 状态列正确；§9 决策记录新增 4 行

🤖 Generated with [Claude Code](https://claude.com/claude-code)