### PR TITLE
feat(sg): add Skywalker.SourceGenerators.Common shared library (Sprint 0 #191 Phase A)

### DIFF
--- a/Skywalker.sln
+++ b/Skywalker.sln
@@ -171,6 +171,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Ddd.Abstractions"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Extensions.DynamicProxies", "src\Skywalker.Extensions.DynamicProxies\Skywalker.Extensions.DynamicProxies.csproj", "{FD00D4F2-7775-48D4-8654-D08F09225497}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.SourceGenerators.Common", "src\Skywalker.SourceGenerators.Common\Skywalker.SourceGenerators.Common.csproj", "{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.SourceGenerators.Common.Tests", "tests\Skywalker.SourceGenerators.Common.Tests\Skywalker.SourceGenerators.Common.Tests.csproj", "{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1141,6 +1145,30 @@ Global
 		{FD00D4F2-7775-48D4-8654-D08F09225497}.Release|x64.Build.0 = Release|Any CPU
 		{FD00D4F2-7775-48D4-8654-D08F09225497}.Release|x86.ActiveCfg = Release|Any CPU
 		{FD00D4F2-7775-48D4-8654-D08F09225497}.Release|x86.Build.0 = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|x64.Build.0 = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Debug|x86.Build.0 = Debug|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|x64.ActiveCfg = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|x64.Build.0 = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|x86.ActiveCfg = Release|Any CPU
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC}.Release|x86.Build.0 = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|x64.Build.0 = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1228,6 +1256,8 @@ Global
 		{6854BF36-115A-45F7-86A3-312415BF92CF} = {CAE4AA71-0C04-4DE4-BC63-54217950DE9A}
 		{42573317-7355-4B1F-9D1F-0551EDEBACAD} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
 		{FD00D4F2-7775-48D4-8654-D08F09225497} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{B54918ED-2B3D-44E8-96E6-BA839FB56ACC} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{5F855A59-3F0D-4F9F-A657-A06C85EE9A21} = {CAE4AA71-0C04-4DE4-BC63-54217950DE9A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1448BD59-570D-4D37-831B-C0872E82B643}

--- a/docs/architecture/source-generators-spec.md
+++ b/docs/architecture/source-generators-spec.md
@@ -376,3 +376,26 @@ Skywalker.Xxx/
 - [ ] 至少 1 个 sample 项目使用该 generator
 - [ ] AOT publish 零警告
 - [ ] `PublicAPI.Unshipped.txt` 更新
+
+## 10. 快速开始
+
+### 10.1 共享 helper
+
+新 Generator 项目无需自己重写 `EquatableArray<T>` / `SymbolExtensions` / 通用诊断。
+[`Skywalker.SourceGenerators.Common`](../../src/Skywalker.SourceGenerators.Common/README.md) 是 source-only 库，
+通过 `<Compile Include>` 把源文件直接编进 Generator 程序集（**不**走 PackageReference / ProjectReference，
+避免 analyzer 加载时的依赖解析问题）：
+
+```xml
+<ItemGroup>
+  <Compile Include="$(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\**\*.cs"
+           Exclude="$(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\bin\**;
+                    $(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\obj\**" />
+</ItemGroup>
+```
+
+### 10.2 Generator 项目脚手架
+
+> 🚧 `dotnet new skywalker-generator` 模板待 Sprint 1 第一个真实 SG 落地后随同发布
+> （[#191](https://github.com/dengxuan/Skywalker/issues/191) Phase B）。
+> 当前请参照 §2.1 csproj 模板手工创建。

--- a/src/Skywalker.SourceGenerators.Common/AnalyzerReleases.Shipped.md
+++ b/src/Skywalker.SourceGenerators.Common/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Skywalker.SourceGenerators.Common/AnalyzerReleases.Unshipped.md
+++ b/src/Skywalker.SourceGenerators.Common/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+SKY9001 | Skywalker.SourceGenerators | Error | Service class must be partial — see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY9001.md

--- a/src/Skywalker.SourceGenerators.Common/AssemblyInfo.cs
+++ b/src/Skywalker.SourceGenerators.Common/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Skywalker.SourceGenerators.Common.Tests")]

--- a/src/Skywalker.SourceGenerators.Common/DiagnosticDescriptors.cs
+++ b/src/Skywalker.SourceGenerators.Common/DiagnosticDescriptors.cs
@@ -1,0 +1,30 @@
+using Microsoft.CodeAnalysis;
+
+namespace Skywalker.SourceGenerators;
+
+/// <summary>
+/// Common diagnostics shared by all Skywalker source generators. Generator-specific diagnostics
+/// (SKY1xxx-SKY5xxx) live in their own generator project.
+/// </summary>
+/// <remarks>
+/// Diagnostic ID segment allocation is documented in <c>docs/architecture/source-generators-spec.md §1.3</c>.
+/// Human-readable docs for each ID live under <c>docs/diagnostics/SKYxxxx.md</c>.
+/// </remarks>
+internal static class DiagnosticDescriptors
+{
+    private const string Category = "Skywalker.SourceGenerators";
+    private const string HelpLinkBase = "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/";
+
+    /// <summary>
+    /// SKY9001 — class marked for SG processing must be declared <c>partial</c>.
+    /// </summary>
+    public static readonly DiagnosticDescriptor MustBePartial = new(
+        id: "SKY9001",
+        title: "Service class must be partial",
+        messageFormat: "Class '{0}' marked with [{1}] must be declared as partial",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Skywalker source generators emit additional members into your class. The class must be declared as 'partial' so the compiler can merge them.",
+        helpLinkUri: HelpLinkBase + "SKY9001.md");
+}

--- a/src/Skywalker.SourceGenerators.Common/EquatableArray.cs
+++ b/src/Skywalker.SourceGenerators.Common/EquatableArray.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Skywalker.SourceGenerators;
+
+/// <summary>
+/// Value-equal wrapper around <see cref="ImmutableArray{T}"/>, suitable for use as a field of
+/// records that flow through the incremental generator pipeline. Using a raw
+/// <see cref="ImmutableArray{T}"/> defeats the per-step caching because its default equality is
+/// reference-based.
+/// </summary>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+    where T : IEquatable<T>
+{
+    public static readonly EquatableArray<T> Empty = new(ImmutableArray<T>.Empty);
+
+    private readonly ImmutableArray<T> _array;
+
+    public EquatableArray(ImmutableArray<T> array) => _array = array;
+
+    public EquatableArray(T[] array) => _array = ImmutableArray.Create(array);
+
+    public int Length => _array.IsDefault ? 0 : _array.Length;
+
+    public bool IsEmpty => Length == 0;
+
+    public T this[int index] => _array[index];
+
+    public ImmutableArray<T> AsImmutableArray() => _array.IsDefault ? ImmutableArray<T>.Empty : _array;
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        var len = Length;
+        if (len != other.Length) return false;
+        for (var i = 0; i < len; i++)
+        {
+            if (!_array[i].Equals(other._array[i])) return false;
+        }
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableArray<T> array && Equals(array);
+
+    public override int GetHashCode()
+    {
+        if (_array.IsDefault) return 0;
+        unchecked
+        {
+            var hash = 17;
+            foreach (var item in _array)
+            {
+                hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+            }
+            return hash;
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        if (_array.IsDefault) yield break;
+        foreach (var item in _array) yield return item;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public static bool operator ==(EquatableArray<T> left, EquatableArray<T> right) => left.Equals(right);
+
+    public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right) => !left.Equals(right);
+
+    public static implicit operator EquatableArray<T>(ImmutableArray<T> array) => new(array);
+
+    public static implicit operator EquatableArray<T>(T[] array) => new(array);
+}

--- a/src/Skywalker.SourceGenerators.Common/README.md
+++ b/src/Skywalker.SourceGenerators.Common/README.md
@@ -1,0 +1,48 @@
+# Skywalker.SourceGenerators.Common
+
+Source-only shared library for Skywalker's internal source generators.
+
+## What this is
+
+A collection of helper types — `EquatableArray<T>`, `SymbolExtensions`, common
+`DiagnosticDescriptors` — that every Skywalker source generator needs but that
+should not be duplicated across generator projects.
+
+## How generator projects consume it
+
+Source-only via `<Compile Include>`, **not** `<ProjectReference>`. Reason: generator
+DLLs are packaged into `analyzers/dotnet/cs` of the host NuGet package, and at
+analyzer-load time the runtime cannot resolve dependencies that are not in that
+same folder. Compiling the shared sources directly into each generator assembly
+sidesteps that problem entirely.
+
+In a generator project's csproj:
+
+```xml
+<ItemGroup>
+  <Compile Include="$(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\**\*.cs"
+           Exclude="$(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\bin\**;
+                    $(MSBuildThisFileDirectory)..\Skywalker.SourceGenerators.Common\obj\**" />
+</ItemGroup>
+```
+
+Each generator project still needs its own `Microsoft.CodeAnalysis.CSharp`
+PackageReference — Common does not transitively provide it via this mechanism.
+
+## How tests consume it
+
+Test projects (`net8.0`) reference Common as a normal `<ProjectReference>`. The
+project still builds a real assembly; only `IsPackable=false` keeps it out of
+NuGet output.
+
+## What lives here
+
+| File | Purpose |
+|---|---|
+| `EquatableArray.cs` | Value-equal wrapper around `ImmutableArray<T>`, required by SG record models |
+| `SymbolExtensions.cs` | `IsPartial`, `GetFullyQualifiedName`, `GetNamespace`, `HasAttributeOfType` |
+| `DiagnosticDescriptors.cs` | Shared diagnostics (SKY9xxx). Generator-specific diagnostics belong in their own generator project. |
+
+Adding a new helper here: keep it generator-shape-agnostic. If a helper only
+applies to one specific SG (e.g. EF-Repository-specific), it belongs in that
+generator project, not here.

--- a/src/Skywalker.SourceGenerators.Common/Skywalker.SourceGenerators.Common.csproj
+++ b/src/Skywalker.SourceGenerators.Common/Skywalker.SourceGenerators.Common.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Source-only 共享库：仅供 Skywalker 内部 Generator 项目通过
+    `<Compile Include="..\Skywalker.SourceGenerators.Common\**\*.cs" />` 拉源码使用。
+    本项目不发布 NuGet 包；但保留正常 build 输出，以便单元测试通过 ProjectReference 验证。
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Roslyn 4.8 是 netstandard2.0 目标且全 nullable-annotated -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Release tracking for analyzer rules (RS2008). -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/Skywalker.SourceGenerators.Common/SymbolExtensions.cs
+++ b/src/Skywalker.SourceGenerators.Common/SymbolExtensions.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Skywalker.SourceGenerators;
+
+internal static class SymbolExtensions
+{
+    /// <summary>
+    /// Whether the type is declared <c>partial</c> in any of its declarations.
+    /// </summary>
+    public static bool IsPartial(this INamedTypeSymbol symbol)
+    {
+        foreach (var declaration in symbol.DeclaringSyntaxReferences)
+        {
+            var syntax = declaration.GetSyntax();
+            if (syntax is TypeDeclarationSyntax typeDecl
+                && typeDecl.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the fully-qualified type name including <c>global::</c> prefix and generic arity,
+    /// suitable for emission into generated source.
+    /// </summary>
+    public static string GetFullyQualifiedName(this ITypeSymbol symbol)
+        => symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+    /// <summary>
+    /// Returns the containing namespace of the type, or empty string if the type is in the global
+    /// namespace.
+    /// </summary>
+    public static string GetNamespace(this INamedTypeSymbol symbol)
+    {
+        var ns = symbol.ContainingNamespace;
+        return ns is null || ns.IsGlobalNamespace ? string.Empty : ns.ToDisplayString();
+    }
+
+    /// <summary>
+    /// Whether the symbol is decorated with an attribute whose fully-qualified type name
+    /// (without generic arity) matches <paramref name="fullyQualifiedMetadataName"/>.
+    /// </summary>
+    public static bool HasAttributeOfType(this ISymbol symbol, string fullyQualifiedMetadataName)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is not null
+                && attrClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == fullyQualifiedMetadataName)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Skywalker.SourceGenerators.Common.Tests/EquatableArrayTests.cs
+++ b/tests/Skywalker.SourceGenerators.Common.Tests/EquatableArrayTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Immutable;
+using Skywalker.SourceGenerators;
+using Xunit;
+
+namespace Skywalker.SourceGenerators.Common.Tests;
+
+public class EquatableArrayTests
+{
+    [Fact]
+    public void Default_IsEmpty()
+    {
+        EquatableArray<int> array = default;
+        Assert.True(array.IsEmpty);
+        Assert.Equal(0, array.Length);
+    }
+
+    [Fact]
+    public void Empty_IsEmpty()
+    {
+        Assert.True(EquatableArray<int>.Empty.IsEmpty);
+        Assert.Equal(0, EquatableArray<int>.Empty.Length);
+    }
+
+    [Fact]
+    public void ConstructFromArray_PreservesElements()
+    {
+        var array = new EquatableArray<int>(new[] { 1, 2, 3 });
+        Assert.Equal(3, array.Length);
+        Assert.Equal(1, array[0]);
+        Assert.Equal(2, array[1]);
+        Assert.Equal(3, array[2]);
+    }
+
+    [Fact]
+    public void ConstructFromImmutableArray_PreservesElements()
+    {
+        var array = new EquatableArray<int>(ImmutableArray.Create(10, 20));
+        Assert.Equal(2, array.Length);
+        Assert.Equal(10, array[0]);
+        Assert.Equal(20, array[1]);
+    }
+
+    [Fact]
+    public void Equals_SameContent_IsTrue()
+    {
+        var a = new EquatableArray<int>(new[] { 1, 2, 3 });
+        var b = new EquatableArray<int>(new[] { 1, 2, 3 });
+        Assert.True(a.Equals(b));
+        Assert.True(a == b);
+        Assert.False(a != b);
+    }
+
+    [Fact]
+    public void Equals_DifferentContent_IsFalse()
+    {
+        var a = new EquatableArray<int>(new[] { 1, 2, 3 });
+        var b = new EquatableArray<int>(new[] { 1, 2, 4 });
+        Assert.False(a.Equals(b));
+        Assert.False(a == b);
+        Assert.True(a != b);
+    }
+
+    [Fact]
+    public void Equals_DifferentLength_IsFalse()
+    {
+        var a = new EquatableArray<int>(new[] { 1, 2, 3 });
+        var b = new EquatableArray<int>(new[] { 1, 2 });
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void Equals_BothEmpty_IsTrue()
+    {
+        EquatableArray<int> a = default;
+        var b = EquatableArray<int>.Empty;
+        Assert.True(a.Equals(b));
+        Assert.True(a == b);
+    }
+
+    [Fact]
+    public void Equals_DefaultVsNonEmpty_IsFalse()
+    {
+        EquatableArray<int> a = default;
+        var b = new EquatableArray<int>(new[] { 1 });
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void GetHashCode_SameContent_IsEqual()
+    {
+        var a = new EquatableArray<int>(new[] { 1, 2, 3 });
+        var b = new EquatableArray<int>(new[] { 1, 2, 3 });
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_Default_IsZero()
+    {
+        EquatableArray<int> a = default;
+        Assert.Equal(0, a.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentOrder_IsDifferent()
+    {
+        var a = new EquatableArray<int>(new[] { 1, 2, 3 });
+        var b = new EquatableArray<int>(new[] { 3, 2, 1 });
+        Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void Enumerate_DefaultArray_YieldsNothing()
+    {
+        EquatableArray<int> a = default;
+        var count = 0;
+        foreach (var _ in a) count++;
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void Enumerate_PopulatedArray_YieldsAll()
+    {
+        var a = new EquatableArray<int>(new[] { 5, 6, 7 });
+        var collected = new List<int>();
+        foreach (var item in a) collected.Add(item);
+        Assert.Equal(new[] { 5, 6, 7 }, collected);
+    }
+
+    [Fact]
+    public void AsImmutableArray_Default_ReturnsEmpty()
+    {
+        EquatableArray<int> a = default;
+        var imm = a.AsImmutableArray();
+        Assert.True(imm.IsEmpty);
+        Assert.False(imm.IsDefault);
+    }
+
+    [Fact]
+    public void AsImmutableArray_Populated_ReturnsSame()
+    {
+        var source = ImmutableArray.Create(1, 2, 3);
+        var a = new EquatableArray<int>(source);
+        Assert.Equal(source, a.AsImmutableArray());
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromImmutableArray()
+    {
+        EquatableArray<int> a = ImmutableArray.Create(1, 2);
+        Assert.Equal(2, a.Length);
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromArray()
+    {
+        EquatableArray<int> a = new[] { 4, 5 };
+        Assert.Equal(2, a.Length);
+    }
+
+    [Fact]
+    public void Equals_AsObject()
+    {
+        var a = new EquatableArray<string>(new[] { "x", "y" });
+        object boxed = new EquatableArray<string>(new[] { "x", "y" });
+        Assert.True(a.Equals(boxed));
+        Assert.False(a.Equals("not-an-array"));
+    }
+
+    [Fact]
+    public void RecordEquality_WorksAcrossEquatableArrayField()
+    {
+        var a = new TestModel("foo", new EquatableArray<int>(new[] { 1, 2 }));
+        var b = new TestModel("foo", new EquatableArray<int>(new[] { 1, 2 }));
+        var c = new TestModel("foo", new EquatableArray<int>(new[] { 1, 3 }));
+
+        Assert.Equal(a, b);
+        Assert.NotEqual(a, c);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    private sealed record TestModel(string Name, EquatableArray<int> Numbers);
+}

--- a/tests/Skywalker.SourceGenerators.Common.Tests/Skywalker.SourceGenerators.Common.Tests.csproj
+++ b/tests/Skywalker.SourceGenerators.Common.Tests/Skywalker.SourceGenerators.Common.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Skywalker.SourceGenerators.Common\Skywalker.SourceGenerators.Common.csproj" />
+  </ItemGroup>
+
+  <!--
+    Common 内部成员对测试可见。
+    InternalsVisibleTo declared in src project below.
+  -->
+
+</Project>


### PR DESCRIPTION
## Summary

Sprint 0 第二批交付。抽出后续每个 SG 都会复用的基础助手到 source-only 共享库 [\`src/Skywalker.SourceGenerators.Common\`](https://github.com/dengxuan/Skywalker/tree/feat/sg-common-library/src/Skywalker.SourceGenerators.Common)，避免每个 Generator 项目重写一遍。

> **本 PR 是 #191 的 Phase A**（Common 库）。Phase B（\`dotnet new skywalker-generator\` 模板）拆出，将随 Sprint 1 第一个真实 SG 落地后再发——避免在没有落地 SG 参考的情况下设计模板而后又改。

## 新增内容

### \`src/Skywalker.SourceGenerators.Common\`（netstandard2.0 / IsPackable=false）

| 文件 | 作用 |
|---|---|
| [\`EquatableArray.cs\`](https://github.com/dengxuan/Skywalker/blob/feat/sg-common-library/src/Skywalker.SourceGenerators.Common/EquatableArray.cs) | 值相等的不可变数组。作为 SG record 模型字段必备（直接用 \`ImmutableArray<T>\` 会因引用相等性击穿增量缓存） |
| [\`SymbolExtensions.cs\`](https://github.com/dengxuan/Skywalker/blob/feat/sg-common-library/src/Skywalker.SourceGenerators.Common/SymbolExtensions.cs) | \`IsPartial\` / \`GetFullyQualifiedName\` / \`GetNamespace\` / \`HasAttributeOfType\` |
| [\`DiagnosticDescriptors.cs\`](https://github.com/dengxuan/Skywalker/blob/feat/sg-common-library/src/Skywalker.SourceGenerators.Common/DiagnosticDescriptors.cs) | \`MustBePartial\`（SKY9001，对接 \`docs/diagnostics/SKY9001.md\`） |
| \`AnalyzerReleases.{Shipped,Unshipped}.md\` | 满足 RS2008 分析器发布跟踪 |
| [\`README.md\`](https://github.com/dengxuan/Skywalker/blob/feat/sg-common-library/src/Skywalker.SourceGenerators.Common/README.md) | source-only 消费方式说明 |

**关键设计：source-only 而非 dll 引用**。每个 Generator 项目通过 \`<Compile Include>\` 把 Common 的源文件直接编进自己的程序集。如果走 \`<ProjectReference>\` 或 \`<PackageReference>\`，运行时 analyzer 加载会因为 \`Common.dll\` 不在 \`analyzers/dotnet/cs\` 目录而失败。

### \`tests/Skywalker.SourceGenerators.Common.Tests\`

20 个 \`EquatableArray<T>\` 单元测试，覆盖：

- \`default\` 状态正确表现为空数组（不是 NRE）
- 值相等、不同长度、不同顺序的 hash code 区分
- 被作为 \`record\` 字段时穿透相等比较
- 隐式转换 from \`ImmutableArray<T>\` / \`T[]\`
- \`AsImmutableArray()\` 在 default 时返回 empty 而非 default

### \`docs/architecture/source-generators-spec.md §10\`

把 Common 的 \`Compile Include\` 模板直接固化到规范文档里，避免每个 SG 作者再去翻 README。Phase B 模板的 placeholder 也在这里登记。

## 设计决策

**不做的事**：

- ❌ \`SourceWriter\` —— 等 Sprint 1 EF Repository SG 实际用到 raw string literal 辅助时再设计，避免空 API
- ❌ \`ModuleInitializerHelpers\` —— 等 Sprint 3 DI 自动注册 SG 时再加
- ❌ 多余的 \`SKY9xxx\` 诊断 —— 仅放当前真实需要的 SKY9001，后续 SG 用到再增
- ❌ \`dotnet new skywalker-generator\` 模板 —— Phase B，参考真实 SG 后定型

## 本地验证

\`\`\`
> dotnet build src/Skywalker.SourceGenerators.Common/Skywalker.SourceGenerators.Common.csproj
已成功生成。  0 个警告  0 个错误

> dotnet test tests/Skywalker.SourceGenerators.Common.Tests
已通过! - 失败: 0，通过: 20，已跳过: 0，总计: 20
\`\`\`

## 关联

- Sprint 0 milestone（v2.0 Sprint 0 - 质量基础设施）
- Epic #182
- 配套：#190（diagnostics 索引页 / SKY9001 文档）已在 #224 PR 提供

## Sprint 0 进度

- [x] #189 EDGE_CASES 清单（PR #224）
- [x] #190 Diagnostics 索引（PR #224）
- [x] #191 Generator Common 库 — **Phase A（本 PR）**
  - [ ] #191 Phase B：\`dotnet new skywalker-generator\` 模板（拆出）
- [ ] #185 SG 测试基础设施（GeneratorTestHelper + Verify）— 下一个
- [ ] #188 PublicApiAnalyzers 接入
- [ ] #187 Sample 矩阵 8 个骨架
- [ ] #186 CI pipeline (sg-quality.yml)

## Test plan

- [ ] CI \`dotnet build src/Skywalker.SourceGenerators.Common/...csproj\` 全绿
- [ ] CI \`dotnet test tests/Skywalker.SourceGenerators.Common.Tests/...csproj\` 20/20 通过
- [ ] Solution \`Skywalker.sln\` 含两个新项目
- [ ] \`AnalyzerReleases.Unshipped.md\` 列出 SKY9001
- [ ] spec.md §10 渲染正常，Compile Include 模板可复制

🤖 Generated with [Claude Code](https://claude.com/claude-code)