### PR TITLE
Use generated EF repository registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Added
 
-- Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，并补充 generator 单元测试。
+- Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试。
 - Source Generator Sprint 0 基础设施：新增 SG 测试项目、`GeneratorTestHelper`、Verify/Roslyn driver 测试流程、`sg-quality.yml` CI、8 个 sample matrix 项目、PublicApiAnalyzers baseline、诊断文档骨架、边界场景清单、`Skywalker.SourceGenerators.Common` 共享库和 `dotnet new skywalker-generator` 模板（#185-#191）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/RepositoryRegistrationGenerator.cs
+++ b/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/RepositoryRegistrationGenerator.cs
@@ -80,6 +80,16 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
         source.AppendLine("#nullable enable");
         source.AppendLine("#pragma warning disable");
         source.AppendLine();
+        source.Append("[assembly: global::Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute(typeof(")
+            .Append(model.DbContextTypeName)
+            .Append("), typeof(global::Microsoft.Extensions.DependencyInjection.")
+            .Append(model.Identifier)
+            .Append("SkywalkerRepositoryRegistrations), nameof(global::Microsoft.Extensions.DependencyInjection.")
+            .Append(model.Identifier)
+            .Append("SkywalkerRepositoryRegistrations.AddSkywalkerGeneratedRepositoriesFor")
+            .Append(model.Identifier)
+            .AppendLine("))]");
+        source.AppendLine();
         source.AppendLine("namespace Microsoft.Extensions.DependencyInjection;");
         source.AppendLine();
         source.Append("internal static class ").Append(model.Identifier).AppendLine("SkywalkerRepositoryRegistrations");

--- a/src/Skywalker.Ddd.EntityFrameworkCore/Microsoft/Extensions/DependencyInjection/EntityFrameworkCoreIServiceCollectionExtensions.cs
+++ b/src/Skywalker.Ddd.EntityFrameworkCore/Microsoft/Extensions/DependencyInjection/EntityFrameworkCoreIServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Skywalker.Ddd.EntityFrameworkCore.DbContextConfiguration;
 using Skywalker.Ddd.Uow.EntityFrameworkCore;
 using Skywalker.Identity.Domain.Repositories;
 using System.Linq;
+using System.Reflection;
 
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,11 @@ public static class EntityFrameworkCoreIServiceCollectionExtensions
     /// <returns>���񼯺ϡ�</returns>
     private static IServiceCollection AddDefaultServices<TDbContext>(this IServiceCollection services) where TDbContext : SkywalkerDbContext<TDbContext>
     {
+        if (TryAddGeneratedDefaultServices<TDbContext>(services))
+        {
+            return services;
+        }
+
         var dbContextType = typeof(TDbContext);
         var entityTypes = DbContextHelper.GetEntityTypes(dbContextType);
         foreach (var entityType in entityTypes)
@@ -49,6 +55,35 @@ public static class EntityFrameworkCoreIServiceCollectionExtensions
             }
         }
         return services;
+    }
+
+    private static bool TryAddGeneratedDefaultServices<TDbContext>(IServiceCollection services) where TDbContext : SkywalkerDbContext<TDbContext>
+    {
+        var dbContextType = typeof(TDbContext);
+        foreach (var attribute in dbContextType.Assembly.GetCustomAttributes<SkywalkerGeneratedRepositoryRegistrationAttribute>())
+        {
+            if (attribute.DbContextType != dbContextType)
+            {
+                continue;
+            }
+
+            var method = attribute.RegistrarType.GetMethod(
+                attribute.MethodName,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                binder: null,
+                types: [typeof(IServiceCollection)],
+                modifiers: null);
+
+            if (method is null || !typeof(IServiceCollection).IsAssignableFrom(method.ReturnType))
+            {
+                continue;
+            }
+
+            method.Invoke(null, [services]);
+            return true;
+        }
+
+        return false;
     }
 
     private static void RegisterDefaultRepository(IServiceCollection services, Type entityType, Type repositoryImplType, Type? primaryKeyType = null)

--- a/src/Skywalker.Ddd.EntityFrameworkCore/PublicAPI.Unshipped.txt
+++ b/src/Skywalker.Ddd.EntityFrameworkCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute
+Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute.DbContextType.get -> System.Type!
+Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute.MethodName.get -> string!
+Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute.RegistrarType.get -> System.Type!
+Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute.SkywalkerGeneratedRepositoryRegistrationAttribute(System.Type! dbContextType, System.Type! registrarType, string! methodName) -> void

--- a/src/Skywalker.Ddd.EntityFrameworkCore/Skywalker/Ddd/EntityFrameworkCore/SkywalkerGeneratedRepositoryRegistrationAttribute.cs
+++ b/src/Skywalker.Ddd.EntityFrameworkCore/Skywalker/Ddd/EntityFrameworkCore/SkywalkerGeneratedRepositoryRegistrationAttribute.cs
@@ -1,0 +1,18 @@
+namespace Skywalker.Ddd.EntityFrameworkCore;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class SkywalkerGeneratedRepositoryRegistrationAttribute : Attribute
+{
+    public SkywalkerGeneratedRepositoryRegistrationAttribute(Type dbContextType, Type registrarType, string methodName)
+    {
+        DbContextType = dbContextType;
+        RegistrarType = registrarType;
+        MethodName = methodName;
+    }
+
+    public Type DbContextType { get; }
+
+    public Type RegistrarType { get; }
+
+    public string MethodName { get; }
+}

--- a/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
+++ b/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.EntityFrameworkCore;
+
+[assembly: SkywalkerGeneratedRepositoryRegistrationAttribute(
+    typeof(Skywalker.Ddd.Tests.GeneratedRegistrationDbContext),
+    typeof(Skywalker.Ddd.Tests.GeneratedRegistrationRegistrar),
+    nameof(Skywalker.Ddd.Tests.GeneratedRegistrationRegistrar.AddGeneratedServices))]
+
+namespace Skywalker.Ddd.Tests;
+
+public sealed class GeneratedRepositoryRegistrationBridgeTests
+{
+    [Fact]
+    public void AddSkywalkerDbContext_UsesGeneratedRegistration_WhenAssemblyMetadataExists()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSkywalker(typeof(GeneratedRepositoryRegistrationBridgeTests).Assembly);
+
+        services.AddSkywalkerDbContext<GeneratedRegistrationDbContext>(options =>
+        {
+            options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("GeneratedRegistrationTestDb"));
+        });
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(GeneratedRegistrationMarker));
+    }
+}
+
+public sealed class GeneratedRegistrationDbContext(DbContextOptions<GeneratedRegistrationDbContext> options) : SkywalkerDbContext<GeneratedRegistrationDbContext>(options)
+{
+    public DbSet<GeneratedRegistrationEntity> Entities { get; set; } = default!;
+}
+
+public sealed class GeneratedRegistrationEntity : Entity<int>
+{
+}
+
+public sealed class GeneratedRegistrationMarker
+{
+}
+
+internal static class GeneratedRegistrationRegistrar
+{
+    public static IServiceCollection AddGeneratedServices(IServiceCollection services)
+    {
+        services.AddTransient<GeneratedRegistrationMarker>();
+        return services;
+    }
+}

--- a/tests/Skywalker.SourceGenerators.Tests/RepositoryRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/RepositoryRegistrationGeneratorTests.cs
@@ -44,6 +44,7 @@ public sealed class RepositoryRegistrationGeneratorTests
         var generatedSource = generatedTree.GetText().ToString();
 
         Assert.EndsWith("Demo_SalesDbContext.SkywalkerRepositoryRegistrations.g.cs", generatedTree.FilePath);
+        Assert.Contains("[assembly: global::Skywalker.Ddd.EntityFrameworkCore.SkywalkerGeneratedRepositoryRegistrationAttribute", generatedSource);
         Assert.Contains("AddSkywalkerGeneratedRepositoriesForDemo_SalesDbContext", generatedSource);
         Assert.Contains("IRepository<global::Demo.Order, int>", generatedSource);
         Assert.Contains("Repository<global::Demo.SalesDbContext, global::Demo.Order, int>", generatedSource);


### PR DESCRIPTION
## Summary

Connects the generated EF repository registrations to the runtime registration path.

- Adds `SkywalkerGeneratedRepositoryRegistrationAttribute` as the runtime metadata bridge.
- Updates `AddSkywalkerDbContext<TDbContext>()` to prefer generated registration when metadata exists.
- Keeps the existing reflection-based registration as fallback when generated metadata is absent.
- Adds a runtime integration test proving `AddSkywalkerDbContext<TDbContext>()` can invoke generated registration metadata.
- Updates `CHANGELOG.md [Unreleased]`.

## Validation

- `dotnet run --project samples\Skywalker.Sample.Minimal\Skywalker.Sample.Minimal.csproj --configuration Release --no-build`
- `dotnet build Skywalker.sln --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet test Skywalker.sln --configuration Release --no-build --verbosity minimal -m:1`

Stacked PR 2/3. Base: `feat/sg-ef-repository-generator`.