### PR TITLE
Wire EF repository generator into minimal sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Added
 
-- Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试。
+- Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - Source Generator Sprint 0 基础设施：新增 SG 测试项目、`GeneratorTestHelper`、Verify/Roslyn driver 测试流程、`sg-quality.yml` CI、8 个 sample matrix 项目、PublicApiAnalyzers baseline、诊断文档骨架、边界场景清单、`Skywalker.SourceGenerators.Common` 共享库和 `dotnet new skywalker-generator` 模板（#185-#191）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,15 +6,15 @@ case that should stay buildable and runnable in CI as generators are added.
 
 ## Current State
 
-Sprint 0 creates the skeleton only. Each sample currently contains a minimal
-`Program.cs` smoke test and a README that describes the scenario it will validate.
-Real generator-driven code is filled in during Sprint 1+.
+Sprint 0 created the sample matrix skeleton. Sprint 1 starts filling it in with
+real generator-driven code. Each sample should stay buildable and runnable in CI
+as it moves from placeholder to scenario canary.
 
 ## Sample Matrix
 
 | Sample | Scenario | Sprint 0 status | Filled in by |
 |---|---|---|---|
-| `Skywalker.Sample.Minimal` | Smallest app; package install + `AddSkywalker()` happy path | Skeleton, build/run smoke test | Sprint 1, Sprint 3 |
+| `Skywalker.Sample.Minimal` | Smallest app; EF repository generator analyzer + `AddSkywalkerDbContext<TDbContext>()` happy path | Sprint 1 smoke test: generated metadata + repository/domain-service registration | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.MultiDbContext` | Multiple EF Core DbContexts without generated-name collisions | Skeleton, build/run smoke test | Sprint 1 |
 | `Skywalker.Sample.GenericServices` | Open and closed generic application services | Skeleton, build/run smoke test | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.NestedTypes` | Nested partial types and fully-qualified generated names | Skeleton, build/run smoke test | Sprint 3 |

--- a/samples/Skywalker.Sample.Minimal/Program.cs
+++ b/samples/Skywalker.Sample.Minimal/Program.cs
@@ -1,4 +1,55 @@
-// Sprint 0 skeleton. Sprint 1+ will replace this with a real `AddSkywalker()` boot
-// path that the EF-Repository / DI / DynamicProxy generators all process.
-Console.WriteLine("Sample: Minimal — placeholder for v2.0 SG verification.");
-Console.WriteLine("Validates: package install + AddSkywalker() one-liner boot.");
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Domain.Services;
+using Skywalker.Ddd.EntityFrameworkCore;
+
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddSkywalkerDbContext<MinimalDbContext>(options =>
+{
+	options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.Minimal"));
+});
+
+var generatedRegistration = typeof(MinimalDbContext).Assembly
+	.GetCustomAttributes(typeof(SkywalkerGeneratedRepositoryRegistrationAttribute), inherit: false)
+	.OfType<SkywalkerGeneratedRepositoryRegistrationAttribute>()
+	.SingleOrDefault(attribute => attribute.DbContextType == typeof(MinimalDbContext));
+
+Ensure(generatedRegistration is not null, "EF repository generator did not emit registration metadata.");
+EnsureRegistered<IRepository<MinimalOrder, Guid>>(services);
+EnsureRegistered<IRepository<MinimalAuditLog>>(services);
+EnsureRegistered<IDomainService<MinimalOrder, Guid>>(services);
+EnsureRegistered<IDomainService<MinimalAuditLog>>(services);
+
+Console.WriteLine("Sample: Minimal — EF repository source generator registration verified.");
+
+static void EnsureRegistered<TService>(IServiceCollection services)
+{
+	Ensure(services.Any(descriptor => descriptor.ServiceType == typeof(TService)), $"Missing service registration: {typeof(TService).FullName}");
+}
+
+static void Ensure(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}
+
+public sealed class MinimalDbContext(DbContextOptions<MinimalDbContext> options) : SkywalkerDbContext<MinimalDbContext>(options)
+{
+	public DbSet<MinimalOrder> Orders { get; set; } = default!;
+
+	public DbSet<MinimalAuditLog> AuditLogs { get; set; } = default!;
+}
+
+public sealed class MinimalOrder : Entity<Guid>
+{
+}
+
+public sealed class MinimalAuditLog : Entity
+{
+	public override object[] GetKeys() => [];
+}

--- a/samples/Skywalker.Sample.Minimal/Skywalker.Sample.Minimal.csproj
+++ b/samples/Skywalker.Sample.Minimal/Skywalker.Sample.Minimal.csproj
@@ -1,2 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Turns `Skywalker.Sample.Minimal` from a Sprint 0 placeholder into a real Sprint 1 smoke sample.

- References the EF repository source generator as an analyzer.
- Defines a minimal DbContext with keyed and non-key entities.
- Verifies generated registration metadata exists at runtime.
- Verifies `AddSkywalkerDbContext<TDbContext>()` registers repository/domain-service contracts.
- Updates sample matrix documentation and `CHANGELOG.md [Unreleased]`.

## Validation

- `dotnet run --project samples\Skywalker.Sample.Minimal\Skywalker.Sample.Minimal.csproj --configuration Release --no-build`
- `dotnet build Skywalker.sln --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet test Skywalker.sln --configuration Release --no-build --verbosity minimal -m:1`

Stacked PR 3/3. Base: `feat/sg-ef-repository-runtime-bridge`.