### PR TITLE
Fix analyzer-only packaging for EF repository generator

### DIFF
--- a/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj
+++ b/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj
@@ -5,6 +5,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>


### PR DESCRIPTION
Fixes the release/2.0 pack failure introduced by the EF repository source generator package.

Summary:
- disables NuGet package analysis for the analyzer-only generator package
- disables symbol package generation for the analyzer-only package to avoid empty `.snupkg` creation

Validation:
- `dotnet pack src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj --configuration Release --no-restore -m:1 --nologo --verbosity:minimal /p:PackageOutputPath=artifacts\pack-validation\sg-analyzer`
- `dotnet pack Skywalker.sln --configuration Release --no-restore -m:1 --nologo --verbosity:minimal /p:PackageOutputPath=artifacts\pack-validation\solution`

No changelog needed