### PR TITLE
Add MultiDbContext repository generator sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
+- `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。
 - Source Generator Sprint 0 基础设施：新增 SG 测试项目、`GeneratorTestHelper`、Verify/Roslyn driver 测试流程、`sg-quality.yml` CI、8 个 sample matrix 项目、PublicApiAnalyzers baseline、诊断文档骨架、边界场景清单、`Skywalker.SourceGenerators.Common` 共享库和 `dotnet new skywalker-generator` 模板（#185-#191）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,7 +15,7 @@ as it moves from placeholder to scenario canary.
 | Sample | Scenario | Sprint 0 status | Filled in by |
 |---|---|---|---|
 | `Skywalker.Sample.Minimal` | Smallest app; EF repository generator analyzer + `AddSkywalkerDbContext<TDbContext>()` happy path | Sprint 1 smoke test: generated metadata + repository/domain-service registration | Sprint 1, Sprint 3 |
-| `Skywalker.Sample.MultiDbContext` | Multiple EF Core DbContexts without generated-name collisions | Skeleton, build/run smoke test | Sprint 1 |
+| `Skywalker.Sample.MultiDbContext` | Multiple EF Core DbContexts without generated-name collisions | Sprint 1 smoke test: generated metadata + repository/domain-service registration for two DbContexts | Sprint 1 |
 | `Skywalker.Sample.GenericServices` | Open and closed generic application services | Skeleton, build/run smoke test | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.NestedTypes` | Nested partial types and fully-qualified generated names | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.InternalServices` | `internal` service types generated in the same assembly | Skeleton, build/run smoke test | Sprint 3 |

--- a/samples/Skywalker.Sample.MultiDbContext/Program.cs
+++ b/samples/Skywalker.Sample.MultiDbContext/Program.cs
@@ -1,2 +1,73 @@
-Console.WriteLine("Sample: MultiDbContext — placeholder for v2.0 SG verification.");
-Console.WriteLine("Validates: two DbContexts coexist, EF-Repository SG disambiguates registrations.");
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Domain.Services;
+using Skywalker.Ddd.EntityFrameworkCore;
+
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddSkywalkerDbContext<CatalogDbContext>(options =>
+{
+	options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.MultiDbContext.Catalog"));
+});
+services.AddSkywalkerDbContext<BillingDbContext>(options =>
+{
+	options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.MultiDbContext.Billing"));
+});
+
+var generatedRegistrations = typeof(CatalogDbContext).Assembly
+	.GetCustomAttributes(typeof(SkywalkerGeneratedRepositoryRegistrationAttribute), inherit: false)
+	.OfType<SkywalkerGeneratedRepositoryRegistrationAttribute>()
+	.ToArray();
+
+var catalogRegistration = EnsureGeneratedRegistration<CatalogDbContext>(generatedRegistrations);
+var billingRegistration = EnsureGeneratedRegistration<BillingDbContext>(generatedRegistrations);
+
+Ensure(catalogRegistration.RegistrarType != billingRegistration.RegistrarType, "Generated registrars for two DbContexts should be distinct.");
+EnsureRegistered<IRepository<CatalogItem, Guid>>(services);
+EnsureRegistered<IDomainService<CatalogItem, Guid>>(services);
+EnsureRegistered<IRepository<BillingInvoice, long>>(services);
+EnsureRegistered<IDomainService<BillingInvoice, long>>(services);
+
+Console.WriteLine("Sample: MultiDbContext — EF repository generator handles two DbContexts.");
+
+static SkywalkerGeneratedRepositoryRegistrationAttribute EnsureGeneratedRegistration<TDbContext>(SkywalkerGeneratedRepositoryRegistrationAttribute[] registrations)
+	where TDbContext : DbContext
+{
+	var registration = registrations.SingleOrDefault(attribute => attribute.DbContextType == typeof(TDbContext));
+	Ensure(registration is not null, $"EF repository generator did not emit registration metadata for {typeof(TDbContext).FullName}.");
+
+	return registration!;
+}
+
+static void EnsureRegistered<TService>(IServiceCollection services)
+{
+	Ensure(services.Any(descriptor => descriptor.ServiceType == typeof(TService)), $"Missing service registration: {typeof(TService).FullName}");
+}
+
+static void Ensure(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}
+
+public sealed class CatalogDbContext(DbContextOptions<CatalogDbContext> options) : SkywalkerDbContext<CatalogDbContext>(options)
+{
+	public DbSet<CatalogItem> Items { get; set; } = default!;
+}
+
+public sealed class BillingDbContext(DbContextOptions<BillingDbContext> options) : SkywalkerDbContext<BillingDbContext>(options)
+{
+	public DbSet<BillingInvoice> Invoices { get; set; } = default!;
+}
+
+public sealed class CatalogItem : Entity<Guid>
+{
+}
+
+public sealed class BillingInvoice : Entity<long>
+{
+}

--- a/samples/Skywalker.Sample.MultiDbContext/Skywalker.Sample.MultiDbContext.csproj
+++ b/samples/Skywalker.Sample.MultiDbContext/Skywalker.Sample.MultiDbContext.csproj
@@ -1,2 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adds the next focused Sprint 1 sample canary for EF repository source generation.

Summary:
- wires `Skywalker.Sample.MultiDbContext` to the EF Core runtime and repository source generator analyzer
- verifies generated registration metadata for two DbContexts in the same assembly
- asserts generated registrar types are distinct and repository/domain-service registrations are present for both contexts
- updates the sample matrix and `[Unreleased]` changelog

Validation:
- `dotnet build samples\Skywalker.Sample.MultiDbContext\Skywalker.Sample.MultiDbContext.csproj --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet run --project samples\Skywalker.Sample.MultiDbContext\Skywalker.Sample.MultiDbContext.csproj --configuration Release --no-build`
- `dotnet build Skywalker.sln --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet test Skywalker.sln --configuration Release --no-build --verbosity minimal -m:1`