### PR TITLE
Add legacy migration repository generator sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。
+- `Skywalker.Sample.LegacyMigration` 填充为 EF repository source generator 迁移期 smoke sample，验证手写 keyed repository 注册不会被 generated defaults 覆盖，同时缺失的 repository/domain-service 注册会被补齐。
 - Source Generator Sprint 0 基础设施：新增 SG 测试项目、`GeneratorTestHelper`、Verify/Roslyn driver 测试流程、`sg-quality.yml` CI、8 个 sample matrix 项目、PublicApiAnalyzers baseline、诊断文档骨架、边界场景清单、`Skywalker.SourceGenerators.Common` 共享库和 `dotnet new skywalker-generator` 模板（#185-#191）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/samples/README.md
+++ b/samples/README.md
@@ -21,7 +21,7 @@ as it moves from placeholder to scenario canary.
 | `Skywalker.Sample.InternalServices` | `internal` service types generated in the same assembly | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.Modular` | Cross-assembly module discovery and registration | Skeleton, single-project placeholder | Sprint 3 |
 | `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Skeleton; requires local AOT toolchain for publish | Sprint 1+ |
-| `Skywalker.Sample.LegacyMigration` | v1.x manual registration coexisting with v2.0 SG registration | Skeleton, build/run smoke test | Sprint 1, Sprint 5 |
+| `Skywalker.Sample.LegacyMigration` | v1.x manual registration coexisting with v2.0 SG registration | Sprint 1 smoke test: manual keyed repository registration survives generated defaults | Sprint 1, Sprint 5 |
 
 `Skywalker.Sample.RealWorldShop` is intentionally out of this Sprint 0 matrix and
 belongs to a later sprint once the generator stack is mature enough for a full app.

--- a/samples/Skywalker.Sample.LegacyMigration/Program.cs
+++ b/samples/Skywalker.Sample.LegacyMigration/Program.cs
@@ -1,2 +1,67 @@
-Console.WriteLine("Sample: LegacyMigration — placeholder for v2.0 SG verification.");
-Console.WriteLine("Validates: v1.x manual registration coexists with v2.0 SG-driven registration during migration.");
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Domain.Services;
+using Skywalker.Ddd.EntityFrameworkCore;
+using Skywalker.Ddd.Uow.Abstractions;
+using Skywalker.Ddd.Uow.EntityFrameworkCore;
+using Skywalker.EventBus.Abstractions;
+using Skywalker.Extensions.Timezone;
+
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddTransient<IRepository<LegacyOrder, Guid>, LegacyOrderRepository>();
+services.AddSkywalkerDbContext<LegacyDbContext>(options =>
+{
+	options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.LegacyMigration"));
+});
+
+var generatedRegistration = typeof(LegacyDbContext).Assembly
+	.GetCustomAttributes(typeof(SkywalkerGeneratedRepositoryRegistrationAttribute), inherit: false)
+	.OfType<SkywalkerGeneratedRepositoryRegistrationAttribute>()
+	.SingleOrDefault(attribute => attribute.DbContextType == typeof(LegacyDbContext));
+
+Ensure(generatedRegistration is not null, "EF repository generator did not emit registration metadata.");
+EnsureSingleRegistration<IRepository<LegacyOrder, Guid>, LegacyOrderRepository>(services);
+EnsureRegistered<IRepository<LegacyOrder>>(services);
+EnsureRegistered<IDomainService<LegacyOrder, Guid>>(services);
+EnsureRegistered<IDomainService<LegacyOrder>>(services);
+
+Console.WriteLine("Sample: LegacyMigration — manual repository registration coexists with generated defaults.");
+
+static void EnsureSingleRegistration<TService, TImplementation>(IServiceCollection services)
+{
+	var descriptors = services.Where(descriptor => descriptor.ServiceType == typeof(TService)).ToArray();
+	Ensure(descriptors.Length == 1, $"Expected exactly one registration for {typeof(TService).FullName}, found {descriptors.Length}.");
+	Ensure(descriptors[0].ImplementationType == typeof(TImplementation), $"Expected legacy implementation {typeof(TImplementation).FullName} for {typeof(TService).FullName}.");
+}
+
+static void EnsureRegistered<TService>(IServiceCollection services)
+{
+	Ensure(services.Any(descriptor => descriptor.ServiceType == typeof(TService)), $"Missing service registration: {typeof(TService).FullName}");
+}
+
+static void Ensure(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}
+
+public sealed class LegacyDbContext(DbContextOptions<LegacyDbContext> options) : SkywalkerDbContext<LegacyDbContext>(options)
+{
+	public DbSet<LegacyOrder> Orders { get; set; } = default!;
+}
+
+public sealed class LegacyOrder : Entity<Guid>
+{
+}
+
+public sealed class LegacyOrderRepository(
+	IClock clock,
+	IEventBus eventBus,
+	IDbContextProvider<LegacyDbContext> dbContextProvider,
+	IUnitOfWorkAccessor unitOfWorkAccessor)
+	: Repository<LegacyDbContext, LegacyOrder, Guid>(clock, eventBus, dbContextProvider, unitOfWorkAccessor);

--- a/samples/Skywalker.Sample.LegacyMigration/Skywalker.Sample.LegacyMigration.csproj
+++ b/samples/Skywalker.Sample.LegacyMigration/Skywalker.Sample.LegacyMigration.csproj
@@ -1,2 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adds a focused Sprint 1 smoke sample for v1-style manual repository registration coexisting with generated EF repository defaults.

Summary:
- wires `Skywalker.Sample.LegacyMigration` to EF Core and the repository source generator analyzer
- pre-registers a manual keyed repository implementation before `AddSkywalkerDbContext<TDbContext>()`
- verifies generated metadata exists, the manual keyed repository registration is not overwritten, and generated defaults fill missing repository/domain-service registrations
- updates the sample matrix and `[Unreleased]` changelog

Validation:
- `dotnet build samples\Skywalker.Sample.LegacyMigration\Skywalker.Sample.LegacyMigration.csproj --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet run --project samples\Skywalker.Sample.LegacyMigration\Skywalker.Sample.LegacyMigration.csproj --configuration Release --no-build`
- `dotnet build Skywalker.sln --configuration Release --no-restore -m:1 --nologo --verbosity:minimal`
- `dotnet test Skywalker.sln --configuration Release --no-build --verbosity minimal -m:1`