### PR TITLE
Update v2 roadmap Sprint 1 status

### DIFF
--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -1,13 +1,15 @@
 # Skywalker v2.0 路线图
 
-> 状态：**进行中 (In Progress)**　|　目标版本：**v2.0.0**　|　最后更新：2026-04-25
+> 状态：**进行中 (In Progress)**　|　目标版本：**v2.0.0**　|　最后更新：2026-05-01
 
 ## 0. 当前进度
 
 - ✅ [`v1.0.0`](https://github.com/dengxuan/Skywalker/releases/tag/v1.0.0) stable 已发布（2026-04-23）
 - ✅ [`v2.0.0-preview.1`](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1) 通道开通（2026-04-23），用于后续 SG 化迭代的浸泡测试
 - ✅ Messaging/Transport 已 spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex)（已合入 main）
-- ⏳ EF Repository SG / DynamicProxy SG / DI 自动注册 SG 待启动
+- ✅ Sprint 0 Source Generator 质量基础设施已合入 `release/2.0`
+- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/Minimal/MultiDbContext/LegacyMigration canary 已合入，仍需补足 diagnostics、snapshot 覆盖、AOT canary 与 preview 浸泡
+- ⏳ DynamicProxy SG / DI 自动注册 SG 待启动
 
 ## 1. 定位 (Positioning)
 
@@ -36,7 +38,7 @@ Slogan:
 
 | # | 项目 | 现状 | v2.0 目标 | 状态 |
 |---|---|---|---|---|
-| 1 | EF Repository 注册 | 反射 `MakeGenericType` | SG 编译期生成 | ⏳ |
+| 1 | EF Repository 注册 | 反射 `MakeGenericType` | SG 编译期生成 | 🟡 进行中 |
 | 2 | DynamicProxy 拦截器 | Castle.DynamicProxy IL Emit | SG 编译期生成静态代理 | ⏳ |
 | 3 | DI 服务注册 | 部分手动 | `[Service]` / `[ApplicationService]` 标注 + SG | ⏳ |
 | 4 | EventBus Handler 发现 | 反射扫程序集 | SG 编译期收集 | ⏳ |
@@ -66,7 +68,7 @@ Slogan:
 
 > 实际进度：v1.0.0 stable + v2.0.0-preview.1 通道已开（2026-04-23）。原"Sprint 0 必须先于 Sprint 1"的强约束因为 In Scope #8/#9 两项已在 v1.0 期间完成而部分提前；Sprint 0 的 SG 质量基础设施仍是 SG 真正落地前的硬门槛。
 
-### Sprint 0（基础设施）—— 截至 2026-05-12
+### Sprint 0（基础设施）—— 已完成
 
 发版前的"质量地基"。**绝不直接开始写 SG**，先把以下到位：
 
@@ -81,21 +83,27 @@ Slogan:
 - [x] `Generator Common` 库 + `dotnet new` 模板（#191）
 
 输出物：可以直接套用的 SG 开发流程。
-预期产物 tag：`2.0.0-preview.2`（仅含质量基础设施）。
+产物已合入 `release/2.0`，并通过 rolling preview 包与 `sg-quality.yml` 继续验证。
 
 ### Sprint 1（EF Repository SG）—— 2 周
 
 最小可行 SG，验证整套流程。
 
-- [ ] `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目
-- [ ] 替换 `AddDefaultServices<TDbContext>` 反射逻辑
+- [x] `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目
+- [x] `AddDefaultServices<TDbContext>` 优先调用 generated registration，保留 reflection fallback 作为过渡兼容路径
+- [x] generator analyzer-only NuGet 打包接入 rolling package 发布
+- [x] runtime bridge 通过 `SkywalkerGeneratedRepositoryRegistrationAttribute` 调用 consumer assembly 中的 generated registrar
+- [x] 基础 generator/runtime 测试：单 DbContext、多 DbContext、bridge 调用、手写注册不被覆盖
+- [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`LegacyMigration`
 - [ ] ≥ 30 个 snapshot 测试
-- [ ] ≥ 5 个相关 sample 项目
+- [ ] ≥ 5 个相关 sample 项目（当前 3 个）
+- [ ] `AspireAOT` canary 覆盖 EF repository generator 链路
 - [ ] ≥ 5 个 SKYxxxx diagnostic + 文档页
+- [ ] 明确 reflection fallback 的最终保留/移除策略
 - [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用
 - [ ] 浸泡 ≥ 2 周无 P0/P1，进入下一 sprint
 
-里程碑：**EF 模块零反射**。
+里程碑：**EF 模块零反射**。当前为 generated-first 过渡态，仍保留 reflection fallback。
 
 ### Sprint 2（DynamicProxy SG + 移除 Castle）—— 3 周
 


### PR DESCRIPTION
Updates the v2 roadmap to reflect the current state on `release/2.0`.

Summary:
- marks Sprint 0 as completed on the v2 integration line
- records EF Repository SG as in progress instead of not started
- lists the Sprint 1 work already landed: generator project, generated-first runtime bridge, packaging, tests, and Minimal/MultiDbContext/LegacyMigration canaries
- keeps remaining Sprint 1 gaps visible: snapshot coverage, AOT canary, diagnostics, fallback strategy, preview.3, and soak validation

Validation:
- reviewed docs-only diff

No changelog needed