### PR TITLE
Add AspireAOT repository generator canary

### DIFF
--- a/.github/workflows/sg-quality.yml
+++ b/.github/workflows/sg-quality.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Install NativeAOT prerequisites
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
+      - name: Build EF repository generator analyzer
+        run: dotnet build src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj --configuration Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:ContinuousIntegrationBuild=false
+
       - name: Publish AOT sample
         shell: bash
         run: |

--- a/.github/workflows/sg-quality.yml
+++ b/.github/workflows/sg-quality.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Publish AOT sample
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           dotnet publish samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj --configuration Release -p:PublishAot=true 2>&1 | tee aot-publish.log
           if grep -E "warning IL[23][0-9]{3}" aot-publish.log; then
             echo "AOT publish produced IL2xxx/IL3xxx warnings."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。
 - `Skywalker.Sample.LegacyMigration` 填充为 EF repository source generator 迁移期 smoke sample，验证手写 keyed repository 注册不会被 generated defaults 覆盖，同时缺失的 repository/domain-service 注册会被补齐。
+- `Skywalker.Sample.AspireAOT` 填充为 EF repository source generator NativeAOT canary，验证 generated registrar direct-call 合约可发布且不产生 IL2xxx/IL3xxx warnings。
 - Source Generator Sprint 0 基础设施：新增 SG 测试项目、`GeneratorTestHelper`、Verify/Roslyn driver 测试流程、`sg-quality.yml` CI、8 个 sample matrix 项目、PublicApiAnalyzers baseline、诊断文档骨架、边界场景清单、`Skywalker.SourceGenerators.Common` 共享库和 `dotnet new skywalker-generator` 模板（#185-#191）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -8,7 +8,7 @@
 - ✅ [`v2.0.0-preview.1`](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1) 通道开通（2026-04-23），用于后续 SG 化迭代的浸泡测试
 - ✅ Messaging/Transport 已 spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex)（已合入 main）
 - ✅ Sprint 0 Source Generator 质量基础设施已合入 `release/2.0`
-- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/Minimal/MultiDbContext/LegacyMigration canary 已合入，仍需补足 diagnostics、snapshot 覆盖、AOT canary 与 preview 浸泡
+- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/Minimal/MultiDbContext/LegacyMigration/AspireAOT canary 已合入，仍需补足 diagnostics、snapshot 覆盖与 preview 浸泡
 - ⏳ DynamicProxy SG / DI 自动注册 SG 待启动
 
 ## 1. 定位 (Positioning)
@@ -94,10 +94,10 @@ Slogan:
 - [x] generator analyzer-only NuGet 打包接入 rolling package 发布
 - [x] runtime bridge 通过 `SkywalkerGeneratedRepositoryRegistrationAttribute` 调用 consumer assembly 中的 generated registrar
 - [x] 基础 generator/runtime 测试：单 DbContext、多 DbContext、bridge 调用、手写注册不被覆盖
-- [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`LegacyMigration`
+- [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`LegacyMigration`、`AspireAOT`
 - [ ] ≥ 30 个 snapshot 测试
-- [ ] ≥ 5 个相关 sample 项目（当前 3 个）
-- [ ] `AspireAOT` canary 覆盖 EF repository generator 链路
+- [ ] ≥ 5 个相关 sample 项目（当前 4 个）
+- [x] `AspireAOT` canary 覆盖 EF repository generator direct-call 链路
 - [ ] ≥ 5 个 SKYxxxx diagnostic + 文档页
 - [ ] 明确 reflection fallback 的最终保留/移除策略
 - [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用

--- a/samples/README.md
+++ b/samples/README.md
@@ -20,7 +20,7 @@ as it moves from placeholder to scenario canary.
 | `Skywalker.Sample.NestedTypes` | Nested partial types and fully-qualified generated names | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.InternalServices` | `internal` service types generated in the same assembly | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.Modular` | Cross-assembly module discovery and registration | Skeleton, single-project placeholder | Sprint 3 |
-| `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Skeleton; requires local AOT toolchain for publish | Sprint 1+ |
+| `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Sprint 1 smoke test: EF repository generator direct-call contract publishes with no IL2xxx/IL3xxx warnings | Sprint 1+ |
 | `Skywalker.Sample.LegacyMigration` | v1.x manual registration coexisting with v2.0 SG registration | Sprint 1 smoke test: manual keyed repository registration survives generated defaults | Sprint 1, Sprint 5 |
 
 `Skywalker.Sample.RealWorldShop` is intentionally out of this Sprint 0 matrix and

--- a/samples/Skywalker.Sample.AspireAOT/Program.cs
+++ b/samples/Skywalker.Sample.AspireAOT/Program.cs
@@ -1,2 +1,142 @@
-Console.WriteLine("Sample: AspireAOT — placeholder for v2.0 SG verification.");
-Console.WriteLine("Validates: dotnet publish -p:PublishAot=true succeeds; no IL2xxx/IL3xxx warnings (Sprint 1+).");
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Domain.Services;
+using Skywalker.Identity.Domain.Repositories;
+using Skywalker.Sample.AspireAOT;
+
+var services = new ServiceCollection();
+global::Microsoft.Extensions.DependencyInjection.Skywalker_Sample_AspireAOT_AotDbContextSkywalkerRepositoryRegistrations.AddSkywalkerGeneratedRepositoriesForSkywalker_Sample_AspireAOT_AotDbContext(services);
+
+EnsureRegistered<IRepository<AotOrder, Guid>, Repository<AotDbContext, AotOrder, Guid>>(services);
+EnsureRegistered<IRepository<AotOrder>, Repository<AotDbContext, AotOrder, Guid>>(services);
+EnsureRegistered<IDomainService<AotOrder, Guid>, EntityFrameworkCoreDomainService<AotOrder, Guid>>(services);
+EnsureRegistered<IDomainService<AotOrder>, EntityFrameworkCoreDomainService<AotOrder, Guid>>(services);
+
+Console.WriteLine("Sample: AspireAOT — EF repository source generator registration verified.");
+
+static void EnsureRegistered<TService, TImplementation>(IServiceCollection services)
+{
+	Ensure(
+		services.Any(descriptor => descriptor.ServiceType == typeof(TService) && descriptor.ImplementationType == typeof(TImplementation)),
+		$"Missing service registration: {typeof(TService).FullName}");
+}
+
+static void Ensure(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}
+
+namespace Skywalker.Sample.AspireAOT
+{
+	public sealed class AotDbContext : Skywalker.Ddd.EntityFrameworkCore.SkywalkerDbContext<AotDbContext>
+	{
+		public Microsoft.EntityFrameworkCore.DbSet<AotOrder> Orders { get; set; } = default!;
+	}
+
+	public sealed class AotOrder : Skywalker.Ddd.Domain.Entities.Entity<Guid>
+	{
+	}
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+	public sealed class DbSet<TEntity>
+		where TEntity : class
+	{
+	}
+}
+
+namespace Skywalker.Ddd.EntityFrameworkCore
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class SkywalkerGeneratedRepositoryRegistrationAttribute(Type dbContextType, Type registrarType, string methodName) : Attribute
+	{
+		public Type DbContextType { get; } = dbContextType;
+
+		public Type RegistrarType { get; } = registrarType;
+
+		public string MethodName { get; } = methodName;
+	}
+
+	public abstract class SkywalkerDbContext<TDbContext>
+		where TDbContext : SkywalkerDbContext<TDbContext>
+	{
+	}
+}
+
+namespace Skywalker.Ddd.Domain.Entities
+{
+	public interface IEntity
+	{
+	}
+
+	public interface IEntity<TKey> : IEntity
+	{
+	}
+
+	public abstract class Entity<TKey> : IEntity<TKey>
+	{
+	}
+}
+
+namespace Skywalker.Ddd.Domain.Repositories
+{
+	public interface IReadOnlyRepository<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity
+	{
+	}
+
+	public interface IReadOnlyRepository<TEntity, TKey> : IReadOnlyRepository<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+
+	public interface IBasicRepository<TEntity> : IReadOnlyRepository<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity
+	{
+	}
+
+	public interface IBasicRepository<TEntity, TKey> : IBasicRepository<TEntity>, IReadOnlyRepository<TEntity, TKey>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+
+	public interface IRepository<TEntity> : IBasicRepository<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity
+	{
+	}
+
+	public interface IRepository<TEntity, TKey> : IRepository<TEntity>, IBasicRepository<TEntity, TKey>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+
+	public sealed class Repository<TDbContext, TEntity, TKey> : IRepository<TEntity, TKey>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+}
+
+namespace Skywalker.Ddd.Domain.Services
+{
+	public interface IDomainService<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity
+	{
+	}
+
+	public interface IDomainService<TEntity, TKey> : IDomainService<TEntity>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+}
+
+namespace Skywalker.Identity.Domain.Repositories
+{
+	public sealed class EntityFrameworkCoreDomainService<TEntity, TKey> : Skywalker.Ddd.Domain.Services.IDomainService<TEntity, TKey>
+		where TEntity : class, Skywalker.Ddd.Domain.Entities.IEntity<TKey>
+	{
+	}
+}

--- a/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
+++ b/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
@@ -7,6 +7,7 @@
       InvariantGlobalization on by default to mirror typical AOT services.
     -->
     <InvariantGlobalization>true</InvariantGlobalization>
+    <EnableSourceLink Condition="'$(PublishAot)' == 'true'">false</EnableSourceLink>
     <EnableSourceControlManagerQueries Condition="'$(PublishAot)' == 'true'">false</EnableSourceControlManagerQueries>
 
     <!--
@@ -20,15 +21,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PublishAot)' != 'true'">
-    <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="ContinuousIntegrationBuild=false;DeterministicSourcePaths=false;EnableSourceControlManagerQueries=false" />
+    <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="EnableSourceLink=false;EnableSourceControlManagerQueries=false;PublishRepositoryUrl=false;EmbedUntrackedSources=false;ContinuousIntegrationBuild=false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <Analyzer Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.dll" />
   </ItemGroup>
-
-  <Target Name="BuildEntityFrameworkCoreSourceGeneratorForAotPublish" BeforeTargets="CoreCompile" Condition="'$(PublishAot)' == 'true' and '$(NoBuild)' != 'true'">
-    <MSBuild Projects="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration);PublishAot=false;PublishTrimmed=false;SelfContained=false;ContinuousIntegrationBuild=false;DeterministicSourcePaths=false;EnableSourceControlManagerQueries=false" RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers" />
-  </Target>
 
 </Project>

--- a/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
+++ b/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PublishAot)' != 'true'">
-    <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="ContinuousIntegrationBuild=false;DeterministicSourcePaths=false;EnableSourceControlManagerQueries=false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <Target Name="BuildEntityFrameworkCoreSourceGeneratorForAotPublish" BeforeTargets="CoreCompile" Condition="'$(PublishAot)' == 'true' and '$(NoBuild)' != 'true'">
-		<MSBuild Projects="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration);PublishAot=false;PublishTrimmed=false;SelfContained=false;EnableSourceControlManagerQueries=false" RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers" />
+    <MSBuild Projects="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration);PublishAot=false;PublishTrimmed=false;SelfContained=false;ContinuousIntegrationBuild=false;DeterministicSourcePaths=false;EnableSourceControlManagerQueries=false" RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers" />
   </Target>
 
 </Project>

--- a/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
+++ b/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
@@ -6,14 +6,29 @@
       bar bites only when running `dotnet publish -p:PublishAot=true`. Keep
       InvariantGlobalization on by default to mirror typical AOT services.
     -->
-    <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <EnableSourceControlManagerQueries Condition="'$(PublishAot)' == 'true'">false</EnableSourceControlManagerQueries>
 
     <!--
-      During Sprint 0 the goal is "AOT publish must succeed". Zero IL2xxx / IL3xxx
-      warnings is enforced by Sprint 1+ when each generator's AOT story lands.
-      Keeping the warnings as warnings (not errors) until then.
+      This sample is the NativeAOT canary for source-generator driven code paths.
+      The sg-quality workflow fails if publishing emits IL2xxx / IL3xxx warnings.
     -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PublishAot)' != 'true'">
+    <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <Analyzer Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.dll" />
+  </ItemGroup>
+
+  <Target Name="BuildEntityFrameworkCoreSourceGeneratorForAotPublish" BeforeTargets="CoreCompile" Condition="'$(PublishAot)' == 'true' and '$(NoBuild)' != 'true'">
+		<MSBuild Projects="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration);PublishAot=false;PublishTrimmed=false;SelfContained=false;EnableSourceControlManagerQueries=false" RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
## Summary
- Fill `Skywalker.Sample.AspireAOT` as a NativeAOT canary for the EF repository source generator direct-call contract.
- Keep the canary focused on generated registrar rooting and DI registrations, avoiding unrelated EF runtime AOT debt.
- Make the AOT workflow fail correctly when `dotnet publish` fails, not only when IL warnings are detected.
- Update the sample matrix, changelog, and v2.0 roadmap status.

## Validation
- `dotnet build samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj --configuration Release -p:EnableSourceControlManagerQueries=false -m:1 --nologo --verbosity:minimal`
- `dotnet run --project samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj --configuration Release --no-build`
- `dotnet publish samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj --configuration Release -p:PublishAot=true -p:EnableSourceControlManagerQueries=false -m:1 --nologo --verbosity:minimal`
- `Select-String artifacts\aspire-aot-publish.log -Pattern "warning IL[23][0-9]{3}"` -> no matches
- `dotnet build Skywalker.sln --configuration Release -p:EnableSourceControlManagerQueries=false -m:1 --nologo --verbosity:minimal`
- `dotnet test Skywalker.sln --configuration Release --no-build -p:EnableSourceControlManagerQueries=false --verbosity minimal -m:1`