### PR TITLE
Add EF repository source generator diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- EF Repository Source Generator 新增 `SKY3001`-`SKY3006` 诊断，覆盖非 public `DbSet`、不可访问实体、缺少 `IEntity`、抽象实体、重复 `DbSet` 暴露和冲突 key type 推断等不支持场景，并补充对应诊断文档与测试（#239）。
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。
 - `Skywalker.Sample.LegacyMigration` 填充为 EF repository source generator 迁移期 smoke sample，验证手写 keyed repository 注册不会被 generated defaults 覆盖，同时缺失的 repository/domain-service 注册会被补齐。

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -17,6 +17,17 @@ the diagnostic ID as the file name: `docs/diagnostics/SKYxxxx.md`.
 | `SKY5xxx` | Permission, localization, and settings generators |
 | `SKY9xxx` | Common source-generator diagnostics |
 
+## EF Repository Generation
+
+| ID | Title |
+|---|---|
+| `SKY3001` | DbSet property must be public instance |
+| `SKY3002` | Entity type must be accessible to generated code |
+| `SKY3003` | Entity type must implement IEntity |
+| `SKY3004` | Entity type must be a concrete class |
+| `SKY3005` | Entity type is exposed by multiple DbSet properties |
+| `SKY3006` | Entity key type inference is ambiguous |
+
 ## Required Page Structure
 
 Each diagnostic page must include:

--- a/docs/diagnostics/SKY3001.md
+++ b/docs/diagnostics/SKY3001.md
@@ -1,0 +1,36 @@
+# SKY3001: DbSet property must be public instance
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The EF repository source generator found a `DbSet<TEntity>` property on a `SkywalkerDbContext<TContext>`, but the property is not a public instance property. Non-public and static DbSet properties are ignored by the generated repository registrar.
+
+## Incorrect Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    internal DbSet<Order> Orders { get; set; } = null!;
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<Order> Orders { get; set; } = null!;
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/docs/diagnostics/SKY3002.md
+++ b/docs/diagnostics/SKY3002.md
@@ -1,0 +1,44 @@
+# SKY3002: Entity type must be accessible to generated code
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The generated repository registrar is an internal type in the target assembly. It can reference public and internal entity types, but it cannot safely reference private or protected nested entity types.
+
+## Incorrect Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<PrivateOrder> Orders { get; set; } = null!;
+
+    private sealed class PrivateOrder : Entity<int>
+    {
+    }
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<Order> Orders { get; set; } = null!;
+}
+
+internal sealed class Order : Entity<int>
+{
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/docs/diagnostics/SKY3003.md
+++ b/docs/diagnostics/SKY3003.md
@@ -1,0 +1,38 @@
+# SKY3003: Entity type must implement IEntity
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The EF repository source generator only generates Skywalker repository registrations for entities that implement `Skywalker.Ddd.Domain.Entities.IEntity`. A plain CLR type can still be used by EF Core, but it does not participate in Skywalker repository generation.
+
+## Incorrect Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<PlainOrder> Orders { get; set; } = null!;
+}
+
+public sealed class PlainOrder
+{
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class Order : Entity<int>
+{
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/docs/diagnostics/SKY3004.md
+++ b/docs/diagnostics/SKY3004.md
@@ -1,0 +1,38 @@
+# SKY3004: Entity type must be a concrete class
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The EF repository source generator found a `DbSet<TEntity>` whose entity type is abstract or otherwise not a concrete class. Repository registrations are emitted only for concrete entity types that can be resolved as runtime services.
+
+## Incorrect Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<AbstractOrder> Orders { get; set; } = null!;
+}
+
+public abstract class AbstractOrder : Entity<int>
+{
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class Order : Entity<int>
+{
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/docs/diagnostics/SKY3005.md
+++ b/docs/diagnostics/SKY3005.md
@@ -1,0 +1,37 @@
+# SKY3005: Entity type is exposed by multiple DbSet properties
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The same entity type appears in more than one `DbSet<TEntity>` property on the same `SkywalkerDbContext<TContext>`. The generator emits one repository registration for the entity and reports this diagnostic so the duplicate model surface is explicit.
+
+## Incorrect Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<Order> Orders { get; set; } = null!;
+    public DbSet<Order> AlsoOrders { get; set; } = null!;
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options)
+    : SkywalkerDbContext<SalesDbContext>(options)
+{
+    public DbSet<Order> Orders { get; set; } = null!;
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/docs/diagnostics/SKY3006.md
+++ b/docs/diagnostics/SKY3006.md
@@ -1,0 +1,35 @@
+# SKY3006: Entity key type inference is ambiguous
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0 |
+| Category | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators |
+
+## Cause
+
+The entity implements `IEntity<TKey>` more than once with different key types. The generator cannot choose a single key type for keyed repository registrations, so it skips that entity and reports the conflict.
+
+## Incorrect Example
+
+```csharp
+public sealed class ConflictingOrder : Entity<int>, IEntity<Guid>
+{
+    Guid IEntity<Guid>.Id => Guid.Empty;
+
+    public bool Equals(Guid other) => false;
+}
+```
+
+## Correct Example
+
+```csharp
+public sealed class Order : Entity<int>
+{
+}
+```
+
+## Related Links
+
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,13 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+SKY3001 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | DbSet property must be public instance - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3001.md
+SKY3002 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | Entity type must be accessible to generated code - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3002.md
+SKY3003 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | Entity type must implement IEntity - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3003.md
+SKY3004 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | Entity type must be a concrete class - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3004.md
+SKY3005 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | Entity type is exposed by multiple DbSet properties - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3005.md
+SKY3006 | Skywalker.Ddd.EntityFrameworkCore.SourceGenerators | Warning | Entity key type inference is ambiguous - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3006.md

--- a/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/RepositoryRegistrationGenerator.cs
+++ b/src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/RepositoryRegistrationGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -15,6 +16,61 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
     private const string DbSetMetadataName = "Microsoft.EntityFrameworkCore.DbSet`1";
     private const string EntityMetadataName = "Skywalker.Ddd.Domain.Entities.IEntity";
     private const string EntityWithKeyMetadataName = "Skywalker.Ddd.Domain.Entities.IEntity`1";
+    private const string Category = "Skywalker.Ddd.EntityFrameworkCore.SourceGenerators";
+
+    private static readonly DiagnosticDescriptor DbSetMustBePublicInstance = new(
+        id: "SKY3001",
+        title: "DbSet property must be public instance",
+        messageFormat: "DbSet property '{0}' on DbContext '{1}' must be a public instance property to participate in repository generation",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3001.md");
+
+    private static readonly DiagnosticDescriptor EntityTypeMustBeAccessible = new(
+        id: "SKY3002",
+        title: "Entity type must be accessible to generated code",
+        messageFormat: "Entity type '{0}' exposed by DbSet property '{1}' must be public or internal so generated repository registrations can reference it",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3002.md");
+
+    private static readonly DiagnosticDescriptor EntityTypeMustImplementEntity = new(
+        id: "SKY3003",
+        title: "Entity type must implement IEntity",
+        messageFormat: "Entity type '{0}' exposed by DbSet property '{1}' must implement Skywalker.Ddd.Domain.Entities.IEntity",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3003.md");
+
+    private static readonly DiagnosticDescriptor EntityTypeMustBeConcreteClass = new(
+        id: "SKY3004",
+        title: "Entity type must be a concrete class",
+        messageFormat: "Entity type '{0}' exposed by DbSet property '{1}' must be a non-abstract class",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3004.md");
+
+    private static readonly DiagnosticDescriptor DuplicateEntityRegistration = new(
+        id: "SKY3005",
+        title: "Entity type is exposed by multiple DbSet properties",
+        messageFormat: "Entity type '{0}' is exposed by multiple DbSet properties on DbContext '{1}': {2}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3005.md");
+
+    private static readonly DiagnosticDescriptor ConflictingEntityKeyTypes = new(
+        id: "SKY3006",
+        title: "Entity key type inference is ambiguous",
+        messageFormat: "Entity type '{0}' implements IEntity<TKey> with conflicting key types: {1}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3006.md");
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -37,29 +93,93 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
         }
 
         var entityBuilder = ImmutableArray.CreateBuilder<EntityRegistrationModel>();
+        var diagnosticBuilder = ImmutableArray.CreateBuilder<DiagnosticModel>();
+        var entityProperties = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         foreach (var member in dbContextSymbol.GetMembers().OfType<IPropertySymbol>())
         {
-            if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
+            if (!TryGetDbSetEntityType(member, out var entityType))
             {
                 continue;
             }
 
-            if (member.Type is not INamedTypeSymbol propertyType
-                || !HasMetadataName(propertyType.ConstructedFrom, DbSetMetadataName)
-                || propertyType.TypeArguments.Length != 1
-                || propertyType.TypeArguments[0] is not INamedTypeSymbol entityType
-                || !Implements(entityType, EntityMetadataName))
+            if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
             {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    DbSetMustBePublicInstance,
+                    member.Locations.FirstOrDefault(),
+                    member.Name,
+                    FormatType(dbContextSymbol)));
+                continue;
+            }
+
+            if (!IsAccessibleToGeneratedCode(entityType))
+            {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    EntityTypeMustBeAccessible,
+                    member.Locations.FirstOrDefault(),
+                    FormatType(entityType),
+                    member.Name));
+                continue;
+            }
+
+            if (!Implements(entityType, EntityMetadataName))
+            {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    EntityTypeMustImplementEntity,
+                    member.Locations.FirstOrDefault(),
+                    FormatType(entityType),
+                    member.Name));
+                continue;
+            }
+
+            if (entityType.TypeKind != TypeKind.Class || entityType.IsAbstract)
+            {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    EntityTypeMustBeConcreteClass,
+                    member.Locations.FirstOrDefault(),
+                    FormatType(entityType),
+                    member.Name));
+                continue;
+            }
+
+            var entityTypeName = entityType.GetFullyQualifiedName();
+            if (!entityProperties.TryGetValue(entityTypeName, out var propertyNames))
+            {
+                propertyNames = new List<string>();
+                entityProperties.Add(entityTypeName, propertyNames);
+            }
+
+            propertyNames.Add(member.Name);
+            if (propertyNames.Count > 1)
+            {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    DuplicateEntityRegistration,
+                    member.Locations.FirstOrDefault(),
+                    FormatType(entityType),
+                    FormatType(dbContextSymbol),
+                    string.Join(", ", propertyNames)));
+                continue;
+            }
+
+            var keyResolution = ResolvePrimaryKeyType(entityType);
+            if (keyResolution.ConflictingKeyTypes is not null)
+            {
+                diagnosticBuilder.Add(DiagnosticModel.Create(
+                    ConflictingEntityKeyTypes,
+                    member.Locations.FirstOrDefault(),
+                    FormatType(entityType),
+                    keyResolution.ConflictingKeyTypes));
                 continue;
             }
 
             entityBuilder.Add(new EntityRegistrationModel(
-                entityType.GetFullyQualifiedName(),
-                FindPrimaryKeyType(entityType)?.GetFullyQualifiedName()));
+                entityTypeName,
+                keyResolution.PrimaryKeyType?.GetFullyQualifiedName()));
         }
 
         var entities = entityBuilder.ToImmutable();
-        if (entities.Length == 0)
+        var diagnostics = diagnosticBuilder.ToImmutable();
+        if (entities.Length == 0 && diagnostics.Length == 0)
         {
             return null;
         }
@@ -67,11 +187,22 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
         return new DbContextRegistrationModel(
             dbContextSymbol.GetFullyQualifiedName(),
             CreateIdentifier(dbContextSymbol),
-            new EquatableArray<EntityRegistrationModel>(entities));
+            new EquatableArray<EntityRegistrationModel>(entities),
+            new EquatableArray<DiagnosticModel>(diagnostics));
     }
 
     private static void Generate(SourceProductionContext context, DbContextRegistrationModel model)
     {
+        foreach (var diagnostic in model.Diagnostics)
+        {
+            context.ReportDiagnostic(diagnostic.Create());
+        }
+
+        if (model.Entities.Length == 0)
+        {
+            return;
+        }
+
         var source = new StringBuilder();
         source.AppendLine("// <auto-generated/>");
         source.AppendLine("// This file was generated by Skywalker Source Generators.");
@@ -155,19 +286,62 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
             .AppendLine(")));");
     }
 
-    private static ITypeSymbol? FindPrimaryKeyType(INamedTypeSymbol entityType)
+    private static KeyResolutionResult ResolvePrimaryKeyType(INamedTypeSymbol entityType)
     {
+        var keyTypes = ImmutableArray.CreateBuilder<ITypeSymbol>();
         foreach (var interfaceType in entityType.AllInterfaces)
         {
-            if (HasMetadataName(interfaceType.ConstructedFrom, EntityWithKeyMetadataName)
-                && interfaceType.TypeArguments.Length == 1)
+            if (!HasMetadataName(interfaceType.ConstructedFrom, EntityWithKeyMetadataName)
+                || interfaceType.TypeArguments.Length != 1)
             {
-                return interfaceType.TypeArguments[0];
+                continue;
+            }
+
+            var keyType = interfaceType.TypeArguments[0];
+            if (!keyTypes.Any(existing => SymbolEqualityComparer.Default.Equals(existing, keyType)))
+            {
+                keyTypes.Add(keyType);
             }
         }
 
-        return null;
+        return keyTypes.Count switch
+        {
+            0 => new KeyResolutionResult(null, null),
+            1 => new KeyResolutionResult(keyTypes[0], null),
+            _ => new KeyResolutionResult(null, string.Join(", ", keyTypes.Select(FormatType)))
+        };
     }
+
+    private static bool TryGetDbSetEntityType(IPropertySymbol property, out INamedTypeSymbol entityType)
+    {
+        entityType = null!;
+        if (property.Type is not INamedTypeSymbol propertyType
+            || !HasMetadataName(propertyType.ConstructedFrom, DbSetMetadataName)
+            || propertyType.TypeArguments.Length != 1
+            || propertyType.TypeArguments[0] is not INamedTypeSymbol dbSetEntityType)
+        {
+            return false;
+        }
+
+        entityType = dbSetEntityType;
+        return true;
+    }
+
+    private static bool IsAccessibleToGeneratedCode(INamedTypeSymbol type)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.ContainingType)
+        {
+            if (current.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal or Accessibility.ProtectedOrInternal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string FormatType(ITypeSymbol type)
+        => type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
 
     private static bool Implements(INamedTypeSymbol type, string metadataName)
         => type.AllInterfaces.Any(interfaceType => HasMetadataName(interfaceType.ConstructedFrom, metadataName));
@@ -207,11 +381,16 @@ public sealed class RepositoryRegistrationGenerator : IIncrementalGenerator
 
 internal readonly struct DbContextRegistrationModel : IEquatable<DbContextRegistrationModel>
 {
-    public DbContextRegistrationModel(string dbContextTypeName, string identifier, EquatableArray<EntityRegistrationModel> entities)
+    public DbContextRegistrationModel(
+        string dbContextTypeName,
+        string identifier,
+        EquatableArray<EntityRegistrationModel> entities,
+        EquatableArray<DiagnosticModel> diagnostics)
     {
         DbContextTypeName = dbContextTypeName;
         Identifier = identifier;
         Entities = entities;
+        Diagnostics = diagnostics;
     }
 
     public string DbContextTypeName { get; }
@@ -220,10 +399,13 @@ internal readonly struct DbContextRegistrationModel : IEquatable<DbContextRegist
 
     public EquatableArray<EntityRegistrationModel> Entities { get; }
 
+    public EquatableArray<DiagnosticModel> Diagnostics { get; }
+
     public bool Equals(DbContextRegistrationModel other)
         => DbContextTypeName == other.DbContextTypeName
             && Identifier == other.Identifier
-            && Entities.Equals(other.Entities);
+            && Entities.Equals(other.Entities)
+            && Diagnostics.Equals(other.Diagnostics);
 
     public override bool Equals(object? obj) => obj is DbContextRegistrationModel other && Equals(other);
 
@@ -235,9 +417,62 @@ internal readonly struct DbContextRegistrationModel : IEquatable<DbContextRegist
             hash = (hash * 31) + DbContextTypeName.GetHashCode();
             hash = (hash * 31) + Identifier.GetHashCode();
             hash = (hash * 31) + Entities.GetHashCode();
+            hash = (hash * 31) + Diagnostics.GetHashCode();
             return hash;
         }
     }
+}
+
+internal readonly struct DiagnosticModel : IEquatable<DiagnosticModel>
+{
+    private DiagnosticModel(DiagnosticDescriptor descriptor, Location? location, EquatableArray<string> messageArgs)
+    {
+        Descriptor = descriptor;
+        Location = location;
+        MessageArgs = messageArgs;
+    }
+
+    public DiagnosticDescriptor Descriptor { get; }
+
+    public Location? Location { get; }
+
+    public EquatableArray<string> MessageArgs { get; }
+
+    public static DiagnosticModel Create(DiagnosticDescriptor descriptor, Location? location, params string[] messageArgs)
+        => new(descriptor, location, new EquatableArray<string>(messageArgs));
+
+    public Diagnostic Create()
+        => Diagnostic.Create(Descriptor, Location, MessageArgs.AsImmutableArray().Cast<object>().ToArray());
+
+    public bool Equals(DiagnosticModel other)
+        => Descriptor.Id == other.Descriptor.Id
+            && MessageArgs.Equals(other.MessageArgs);
+
+    public override bool Equals(object? obj) => obj is DiagnosticModel other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            hash = (hash * 31) + Descriptor.Id.GetHashCode();
+            hash = (hash * 31) + MessageArgs.GetHashCode();
+            return hash;
+        }
+    }
+}
+
+internal readonly struct KeyResolutionResult
+{
+    public KeyResolutionResult(ITypeSymbol? primaryKeyType, string? conflictingKeyTypes)
+    {
+        PrimaryKeyType = primaryKeyType;
+        ConflictingKeyTypes = conflictingKeyTypes;
+    }
+
+    public ITypeSymbol? PrimaryKeyType { get; }
+
+    public string? ConflictingKeyTypes { get; }
 }
 
 internal readonly struct EntityRegistrationModel : IEquatable<EntityRegistrationModel>

--- a/tests/Skywalker.SourceGenerators.Tests/RepositoryRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/RepositoryRegistrationGeneratorTests.cs
@@ -122,6 +122,193 @@ public sealed class RepositoryRegistrationGeneratorTests
         Assert.DoesNotContain("CatalogItem", billingSource.Source);
     }
 
+    [Fact]
+    public void ReportsDiagnostic_ForNonPublicDbSetProperty()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.Domain.Entities;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                internal DbSet<Order> Orders { get; set; } = null!;
+            }
+
+            public sealed class Order : Entity<int>
+            {
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        AssertDiagnostic(
+            result,
+            "SKY3001",
+            "DbSet property 'Orders' on DbContext 'Demo.SalesDbContext' must be a public instance property to participate in repository generation");
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForInaccessibleEntityType()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.Domain.Entities;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                public DbSet<PrivateOrder> Orders { get; set; } = null!;
+
+                private sealed class PrivateOrder : Entity<int>
+                {
+                }
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        AssertDiagnostic(
+            result,
+            "SKY3002",
+            "Entity type 'Demo.SalesDbContext.PrivateOrder' exposed by DbSet property 'Orders' must be public or internal so generated repository registrations can reference it");
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForEntityThatDoesNotImplementIEntity()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                public DbSet<PlainOrder> Orders { get; set; } = null!;
+            }
+
+            public sealed class PlainOrder
+            {
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        AssertDiagnostic(
+            result,
+            "SKY3003",
+            "Entity type 'Demo.PlainOrder' exposed by DbSet property 'Orders' must implement Skywalker.Ddd.Domain.Entities.IEntity");
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForAbstractEntityType()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.Domain.Entities;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                public DbSet<AbstractOrder> Orders { get; set; } = null!;
+            }
+
+            public abstract class AbstractOrder : Entity<int>
+            {
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        AssertDiagnostic(
+            result,
+            "SKY3004",
+            "Entity type 'Demo.AbstractOrder' exposed by DbSet property 'Orders' must be a non-abstract class");
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForDuplicateDbSetEntityRegistration()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.Domain.Entities;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                public DbSet<Order> Orders { get; set; } = null!;
+                public DbSet<Order> AlsoOrders { get; set; } = null!;
+            }
+
+            public sealed class Order : Entity<int>
+            {
+            }
+            """, CreateReferences());
+
+        var generatedSource = Assert.Single(result.GeneratedTrees).GetText().ToString();
+        Assert.Equal(1, CountOccurrences(generatedSource, "IRepository<global::Demo.Order, int>"));
+        AssertDiagnostic(
+            result,
+            "SKY3005",
+            "Entity type 'Demo.Order' is exposed by multiple DbSet properties on DbContext 'Demo.SalesDbContext': Orders, AlsoOrders");
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForConflictingEntityKeyTypes()
+    {
+        var result = GeneratorTestHelper.Run<RepositoryRegistrationGenerator>("""
+            using System;
+            using Microsoft.EntityFrameworkCore;
+            using Skywalker.Ddd.Domain.Entities;
+            using Skywalker.Ddd.EntityFrameworkCore;
+
+            namespace Demo;
+
+            public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+            {
+                public DbSet<ConflictingOrder> Orders { get; set; } = null!;
+            }
+
+            public sealed class ConflictingOrder : Entity<int>, IEntity<Guid>
+            {
+                Guid IEntity<Guid>.Id => Guid.Empty;
+
+                public bool Equals(Guid other) => false;
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        AssertDiagnostic(
+            result,
+            "SKY3006",
+            "Entity type 'Demo.ConflictingOrder' implements IEntity<TKey> with conflicting key types: int, System.Guid");
+    }
+
+    private static void AssertDiagnostic(GeneratorDriverRunResult result, string id, string message)
+    {
+        var diagnostic = Assert.Single(result.Diagnostics, diagnostic => diagnostic.Id == id);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Equal(message, diagnostic.GetMessage());
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+
+        return count;
+    }
+
     private static IEnumerable<MetadataReference> CreateReferences()
     {
         yield return MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location);


### PR DESCRIPTION
Adds first-class diagnostics for unsupported EF repository source generator scenarios.

Summary:
- Adds SKY3001-SKY3006 diagnostics for unsupported DbSet visibility, inaccessible entity types, missing IEntity contracts, abstract entities, duplicate DbSet entity exposure, and conflicting IEntity<TKey> key inference.
- Updates repository registration generation to report diagnostics instead of silently skipping unsupported DbSet/entity shapes.
- Documents each new diagnostic and registers analyzer release tracking metadata.
- Adds xUnit coverage that asserts diagnostic id, severity, and message.

Validation:
- `dotnet test tests\Skywalker.SourceGenerators.Tests\Skywalker.SourceGenerators.Tests.csproj --no-restore -p:EnableSourceControlManagerQueries=false`
- `dotnet build Skywalker.sln --no-restore -p:EnableSourceControlManagerQueries=false`

Closes #239