### PR TITLE
Define EF repository reflection fallback policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- EF Repository registration 明确 reflection fallback 策略：generated registration 优先；fallback 仅作为 non-AOT 兼容路径保留，并可通过 AppContext switch 禁用以验证 AOT/trimmed 边界（#241）。
 - EF Repository Source Generator 新增 `SKY3001`-`SKY3006` 诊断，覆盖非 public `DbSet`、不可访问实体、缺少 `IEntity`、抽象实体、重复 `DbSet` 暴露和冲突 key type 推断等不支持场景，并补充对应诊断文档与测试（#239）。
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。

--- a/docs/architecture/native-aot-repository-provider.md
+++ b/docs/architecture/native-aot-repository-provider.md
@@ -44,6 +44,17 @@ v2 的 EF 目标是：
 - AOT/trimmed 场景下避免 Skywalker 自己引入新的 reflection warning
 - 文档清楚标注 full EF Core NativeAOT 取决于 EF Core 与具体 provider
 
+#### EF reflection fallback policy
+
+v2.0 保留 EF repository reflection fallback 作为 **non-AOT compatibility path**，只服务于尚未启用 source generator 的普通 JIT 应用迁移。最终策略如下：
+
+- generated registration metadata 始终优先；只要 consumer assembly 中存在 `SkywalkerGeneratedRepositoryRegistrationAttribute`，runtime bridge 会调用 generated registrar，不进入 fallback。
+- fallback reflection 仅在 `RuntimeFeature.IsDynamicCodeSupported == true` 且未显式禁用时启用。
+- NativeAOT 下动态代码不可用时，缺失 generated metadata 会失败并提示启用 source generator 或直接调用 generated registrar。
+- trimmed/JIT 应用若要验证 AOT 边界，可设置 AppContext switch `Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback=true`，强制禁止 fallback。
+
+这意味着 AOT 指南不能依赖 fallback reflection。AOT-first 应用必须使用 generated registration path；完整持久化场景仍应按本计划继续推进 Dapper.AOT / ADO.NET repository provider track。
+
 #### EF AOT 支持边界
 
 `Skywalker.Sample.AspireAOT` 是 EF repository source generator 的 **registration contract canary**。它验证：

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -8,7 +8,7 @@
 - ✅ [`v2.0.0-preview.1`](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1) 通道开通（2026-04-23），用于后续 SG 化迭代的浸泡测试
 - ✅ Messaging/Transport 已 spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex)（已合入 main）
 - ✅ Sprint 0 Source Generator 质量基础设施已合入 `release/2.0`
-- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/Minimal/MultiDbContext/LegacyMigration/AspireAOT canary 已合入，仍需补足 diagnostics、snapshot 覆盖与 preview 浸泡
+- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/diagnostics/snapshot 覆盖/Minimal/MultiDbContext/LegacyMigration/AspireAOT canary 已合入，仍需补足 sample 覆盖与 preview 浸泡
 - 🧭 NativeAOT 仓储层备用路线已确定：EF Core 作为 rich ORM provider，Dapper.AOT / ADO.NET provider 作为 v2.x NativeAOT repository path 规划
 - ⏳ DynamicProxy SG / DI 自动注册 SG 待启动
 
@@ -97,16 +97,16 @@ Slogan:
 - [x] runtime bridge 通过 `SkywalkerGeneratedRepositoryRegistrationAttribute` 调用 consumer assembly 中的 generated registrar
 - [x] 基础 generator/runtime 测试：单 DbContext、多 DbContext、bridge 调用、手写注册不被覆盖
 - [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`LegacyMigration`、`AspireAOT`
-- [ ] ≥ 30 个 snapshot 测试
+- [x] ≥ 30 个 snapshot 测试
 - [ ] ≥ 5 个相关 sample 项目（当前 4 个）
 - [x] `AspireAOT` canary 覆盖 EF repository generator direct-call 链路
 - [x] 明确 EF AOT 支持边界：generated registration path AOT-friendly；full EF Core NativeAOT 取决于 EF Core/provider
-- [ ] ≥ 5 个 SKYxxxx diagnostic + 文档页
-- [ ] 明确 reflection fallback 的最终保留/移除策略
+- [x] ≥ 5 个 SKYxxxx diagnostic + 文档页
+- [x] 明确 reflection fallback 的最终保留/移除策略：non-AOT compatibility only；NativeAOT/dynamic-code-disabled 场景缺失 generated metadata 时失败，不依赖 fallback
 - [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用
 - [ ] 浸泡 ≥ 2 周无 P0/P1，进入下一 sprint
 
-里程碑：**EF 模块零反射**。当前为 generated-first 过渡态，仍保留 reflection fallback。
+里程碑：**EF 模块零反射**。当前为 generated-first 过渡态；reflection fallback 仅作为 non-AOT 兼容路径保留。
 
 ### Sprint 2（DynamicProxy SG + 移除 Castle）—— 3 周
 
@@ -213,3 +213,4 @@ v1.x → v2.0 的破坏性变更：
 | 2026-04-25 | Messaging/Transport spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex) | 跨语言通信基础设施定位与 .NET DDD 框架不同步；polyrepo + `Vertex.*` 命名 |
 | 2026-04-25 | 取消 alpha 通道，统一从 preview 起步 | release/2.0 + MinVer + git tag 直接驱动 preview/rc/stable，简化流程 |
 | 2026-05-01 | EF Core 与 NativeAOT repository provider 分线推进 | EF Core 作为 rich ORM provider；Dapper.AOT / ADO.NET 作为 v2.x NativeAOT 仓储层研究方向 |
+| 2026-05-01 | EF repository reflection fallback 仅保留为 non-AOT 兼容路径 | generated registration 优先；NativeAOT/dynamic-code-disabled 场景缺失 generated metadata 时失败 |

--- a/src/Skywalker.Ddd.EntityFrameworkCore/Microsoft/Extensions/DependencyInjection/EntityFrameworkCoreIServiceCollectionExtensions.cs
+++ b/src/Skywalker.Ddd.EntityFrameworkCore/Microsoft/Extensions/DependencyInjection/EntityFrameworkCoreIServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Skywalker.Ddd.Uow.EntityFrameworkCore;
 using Skywalker.Identity.Domain.Repositories;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class EntityFrameworkCoreIServiceCollectionExtensions
 {
+    private const string DisableReflectionRepositoryFallbackSwitch = "Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback";
+
     /// <summary>
     /// ͨ�� DbContext �������Ӳִ��������ȡ���е� DbSet Ȼ�󹹽��ִ���
     /// </summary>
@@ -33,6 +36,11 @@ public static class EntityFrameworkCoreIServiceCollectionExtensions
         }
 
         var dbContextType = typeof(TDbContext);
+        if (!IsReflectionRepositoryFallbackEnabled())
+        {
+            throw new InvalidOperationException($"EF repository source generator did not emit registration metadata for '{dbContextType.FullName}'. Reflection fallback is disabled; enable the source generator or call the generated repository registrar directly.");
+        }
+
         var entityTypes = DbContextHelper.GetEntityTypes(dbContextType);
         foreach (var entityType in entityTypes)
         {
@@ -84,6 +92,16 @@ public static class EntityFrameworkCoreIServiceCollectionExtensions
         }
 
         return false;
+    }
+
+    private static bool IsReflectionRepositoryFallbackEnabled()
+    {
+        if (AppContext.TryGetSwitch(DisableReflectionRepositoryFallbackSwitch, out var disabled) && disabled)
+        {
+            return false;
+        }
+
+        return RuntimeFeature.IsDynamicCodeSupported;
     }
 
     private static void RegisterDefaultRepository(IServiceCollection services, Type entityType, Type repositoryImplType, Type? primaryKeyType = null)

--- a/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
+++ b/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.Domain.Repositories;
 using Skywalker.Ddd.EntityFrameworkCore;
+using Skywalker.Identity.Domain.Repositories;
 
 [assembly: SkywalkerGeneratedRepositoryRegistrationAttribute(
     typeof(Skywalker.Ddd.Tests.GeneratedRegistrationDbContext),
@@ -14,13 +16,12 @@ namespace Skywalker.Ddd.Tests;
 
 public sealed class GeneratedRepositoryRegistrationBridgeTests
 {
+    private const string DisableReflectionRepositoryFallbackSwitch = "Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback";
+
     [Fact]
     public void AddSkywalkerDbContext_UsesGeneratedRegistration_WhenAssemblyMetadataExists()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddSkywalker(typeof(GeneratedRepositoryRegistrationBridgeTests).Assembly);
+        var services = CreateServices();
 
         services.AddSkywalkerDbContext<GeneratedRegistrationDbContext>(options =>
         {
@@ -33,11 +34,8 @@ public sealed class GeneratedRepositoryRegistrationBridgeTests
     [Fact]
     public void AddSkywalkerDbContext_DoesNotOverwriteExistingRegistration_WhenGeneratedRegistrarUsesTryAdd()
     {
-        var services = new ServiceCollection();
+        var services = CreateServices();
         var existingMarker = new GeneratedRegistrationMarker();
-        services.AddLogging();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddSkywalker(typeof(GeneratedRepositoryRegistrationBridgeTests).Assembly);
         services.AddSingleton(existingMarker);
 
         services.AddSkywalkerDbContext<GeneratedRegistrationDbContext>(options =>
@@ -48,6 +46,79 @@ public sealed class GeneratedRepositoryRegistrationBridgeTests
         var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(GeneratedRegistrationMarker));
         Assert.Same(existingMarker, descriptor.ImplementationInstance);
     }
+
+    [Fact]
+    public void AddSkywalkerDbContext_UsesGeneratedRegistration_WhenReflectionFallbackIsDisabled()
+    {
+        AppContext.SetSwitch(DisableReflectionRepositoryFallbackSwitch, true);
+        try
+        {
+            var services = CreateServices();
+
+            services.AddSkywalkerDbContext<GeneratedRegistrationDbContext>(options =>
+            {
+                options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("GeneratedRegistrationNoFallbackDb"));
+            });
+
+            Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(GeneratedRegistrationMarker));
+        }
+        finally
+        {
+            AppContext.SetSwitch(DisableReflectionRepositoryFallbackSwitch, false);
+        }
+    }
+
+    [Fact]
+    public void AddSkywalkerDbContext_UsesReflectionFallback_WhenGeneratedRegistrationMetadataIsMissing()
+    {
+        var services = CreateServices();
+
+        services.AddSkywalkerDbContext<FallbackRegistrationDbContext>(options =>
+        {
+            options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("ReflectionFallbackDb"));
+        });
+
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(IRepository<FallbackRegistrationEntity, int>) &&
+            descriptor.ImplementationType == typeof(Repository<FallbackRegistrationDbContext, FallbackRegistrationEntity, int>));
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(IRepository<FallbackRegistrationEntity>) &&
+            descriptor.ImplementationType == typeof(Repository<FallbackRegistrationDbContext, FallbackRegistrationEntity, int>));
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(Skywalker.Ddd.Domain.Services.IDomainService<FallbackRegistrationEntity, int>) &&
+            descriptor.ImplementationType == typeof(EntityFrameworkCoreDomainService<FallbackRegistrationEntity, int>));
+    }
+
+    [Fact]
+    public void AddSkywalkerDbContext_Throws_WhenGeneratedRegistrationMetadataIsMissingAndReflectionFallbackIsDisabled()
+    {
+        AppContext.SetSwitch(DisableReflectionRepositoryFallbackSwitch, true);
+        try
+        {
+            var services = CreateServices();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => services.AddSkywalkerDbContext<FallbackRegistrationDbContext>(options =>
+            {
+                options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("ReflectionFallbackDisabledDb"));
+            }));
+
+            Assert.Contains("Reflection fallback is disabled", exception.Message);
+            Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IRepository<FallbackRegistrationEntity, int>));
+        }
+        finally
+        {
+            AppContext.SetSwitch(DisableReflectionRepositoryFallbackSwitch, false);
+        }
+    }
+
+    private static IServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSkywalker(typeof(GeneratedRepositoryRegistrationBridgeTests).Assembly);
+        return services;
+    }
 }
 
 public sealed class GeneratedRegistrationDbContext(DbContextOptions<GeneratedRegistrationDbContext> options) : SkywalkerDbContext<GeneratedRegistrationDbContext>(options)
@@ -56,6 +127,15 @@ public sealed class GeneratedRegistrationDbContext(DbContextOptions<GeneratedReg
 }
 
 public sealed class GeneratedRegistrationEntity : Entity<int>
+{
+}
+
+public sealed class FallbackRegistrationDbContext(DbContextOptions<FallbackRegistrationDbContext> options) : SkywalkerDbContext<FallbackRegistrationDbContext>(options)
+{
+    public DbSet<FallbackRegistrationEntity> Entities { get; set; } = default!;
+}
+
+public sealed class FallbackRegistrationEntity : Entity<int>
 {
 }
 


### PR DESCRIPTION
Defines and enforces the EF repository reflection fallback policy for v2.0.

Summary:
- Keeps generated repository registration as the first path.
- Retains reflection fallback only as a non-AOT compatibility path.
- Disables fallback automatically when dynamic code is unsupported, and adds the `Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback` AppContext switch for trimmed/AOT boundary validation.
- Fails clearly when generated metadata is missing while fallback is disabled.
- Adds bridge tests for generated registration, reflection fallback, and fallback-disabled behavior.
- Documents the policy in the NativeAOT repository provider plan and v2.0 roadmap.

Validation:
- `dotnet test tests\Skywalker.Ddd.Tests\Skywalker.Ddd.Tests.csproj --no-build --filter "FullyQualifiedName~GeneratedRepositoryRegistrationBridgeTests"`
- `dotnet test tests\Skywalker.Ddd.Tests\Skywalker.Ddd.Tests.csproj --no-build`
- `dotnet build Skywalker.sln --no-restore -p:EnableSourceControlManagerQueries=false`

Closes #241