### PR TITLE
Add EF repository nested types sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - EF Repository registration 明确 reflection fallback 策略：generated registration 优先；fallback 仅作为 non-AOT 兼容路径保留，并可通过 AppContext switch 禁用以验证 AOT/trimmed 边界（#241）。
+- `Skywalker.Sample.NestedTypes` 填充为 EF repository source generator smoke sample，验证 nested DbContext/entity types 的 generated metadata 与 repository/domain-service 注册（#242）。
 - EF Repository Source Generator 新增 `SKY3001`-`SKY3006` 诊断，覆盖非 public `DbSet`、不可访问实体、缺少 `IEntity`、抽象实体、重复 `DbSet` 暴露和冲突 key type 推断等不支持场景，并补充对应诊断文档与测试（#239）。
 - Sprint 1 EF Repository Source Generator 起步：新增 `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` 项目，先生成 DbContext `DbSet<TEntity>` 对应的默认 repository/domain service 静态注册代码，`AddSkywalkerDbContext<TDbContext>()` 优先调用 generated registration 并保留运行时反射 fallback，同时补充 generator/runtime 单元测试与 `Skywalker.Sample.Minimal` smoke sample。
 - `Skywalker.Sample.MultiDbContext` 填充为 EF repository source generator smoke sample，验证同一应用中两个 DbContext 的 generated registration metadata、registrar 类型和 repository/domain-service 注册彼此独立。

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -8,7 +8,7 @@
 - ✅ [`v2.0.0-preview.1`](https://github.com/dengxuan/Skywalker/releases/tag/v2.0.0-preview.1) 通道开通（2026-04-23），用于后续 SG 化迭代的浸泡测试
 - ✅ Messaging/Transport 已 spin-out 到独立项目 [Vertex](https://github.com/dengxuan/Vertex)（已合入 main）
 - ✅ Sprint 0 Source Generator 质量基础设施已合入 `release/2.0`
-- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/diagnostics/snapshot 覆盖/Minimal/MultiDbContext/LegacyMigration/AspireAOT canary 已合入，仍需补足 sample 覆盖与 preview 浸泡
+- 🟡 Sprint 1 EF Repository SG 已启动：generator/runtime bridge/diagnostics/snapshot 覆盖/5 个 sample canary 已合入，仍需 preview 浸泡
 - 🧭 NativeAOT 仓储层备用路线已确定：EF Core 作为 rich ORM provider，Dapper.AOT / ADO.NET provider 作为 v2.x NativeAOT repository path 规划
 - ⏳ DynamicProxy SG / DI 自动注册 SG 待启动
 
@@ -96,9 +96,9 @@ Slogan:
 - [x] generator analyzer-only NuGet 打包接入 rolling package 发布
 - [x] runtime bridge 通过 `SkywalkerGeneratedRepositoryRegistrationAttribute` 调用 consumer assembly 中的 generated registrar
 - [x] 基础 generator/runtime 测试：单 DbContext、多 DbContext、bridge 调用、手写注册不被覆盖
-- [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`LegacyMigration`、`AspireAOT`
+- [x] 相关 sample canary：`Minimal`、`MultiDbContext`、`NestedTypes`、`LegacyMigration`、`AspireAOT`
 - [x] ≥ 30 个 snapshot 测试
-- [ ] ≥ 5 个相关 sample 项目（当前 4 个）
+- [x] ≥ 5 个相关 sample 项目
 - [x] `AspireAOT` canary 覆盖 EF repository generator direct-call 链路
 - [x] 明确 EF AOT 支持边界：generated registration path AOT-friendly；full EF Core NativeAOT 取决于 EF Core/provider
 - [x] ≥ 5 个 SKYxxxx diagnostic + 文档页

--- a/samples/README.md
+++ b/samples/README.md
@@ -17,7 +17,7 @@ as it moves from placeholder to scenario canary.
 | `Skywalker.Sample.Minimal` | Smallest app; EF repository generator analyzer + `AddSkywalkerDbContext<TDbContext>()` happy path | Sprint 1 smoke test: generated metadata + repository/domain-service registration | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.MultiDbContext` | Multiple EF Core DbContexts without generated-name collisions | Sprint 1 smoke test: generated metadata + repository/domain-service registration for two DbContexts | Sprint 1 |
 | `Skywalker.Sample.GenericServices` | Open and closed generic application services | Skeleton, build/run smoke test | Sprint 1, Sprint 3 |
-| `Skywalker.Sample.NestedTypes` | Nested partial types and fully-qualified generated names | Skeleton, build/run smoke test | Sprint 3 |
+| `Skywalker.Sample.NestedTypes` | Nested DbContext/entity types and fully-qualified generated names | Sprint 1 smoke test: generated metadata + repository/domain-service registration for nested types | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.InternalServices` | `internal` service types generated in the same assembly | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.Modular` | Cross-assembly module discovery and registration | Skeleton, single-project placeholder | Sprint 3 |
 | `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Sprint 1 smoke test: EF repository generator direct-call contract publishes with no IL2xxx/IL3xxx warnings | Sprint 1+ |

--- a/samples/Skywalker.Sample.NestedTypes/Program.cs
+++ b/samples/Skywalker.Sample.NestedTypes/Program.cs
@@ -1,2 +1,60 @@
-Console.WriteLine("Sample: NestedTypes — placeholder for v2.0 SG verification.");
-Console.WriteLine("Validates: SG emits correct names for Outer.Inner.Target — namespace, partial chain, FQN.");
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Ddd.Domain.Entities;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Domain.Services;
+using Skywalker.Ddd.EntityFrameworkCore;
+
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddSkywalkerDbContext<Commerce.SalesDbContext>(options =>
+{
+	options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.NestedTypes"));
+});
+
+var generatedRegistration = typeof(Commerce.SalesDbContext).Assembly
+	.GetCustomAttributes(typeof(SkywalkerGeneratedRepositoryRegistrationAttribute), inherit: false)
+	.OfType<SkywalkerGeneratedRepositoryRegistrationAttribute>()
+	.SingleOrDefault(attribute => attribute.DbContextType == typeof(Commerce.SalesDbContext));
+
+Ensure(generatedRegistration is not null, "EF repository generator did not emit registration metadata for the nested DbContext.");
+EnsureRegistered<IRepository<Commerce.Order, Guid>>(services);
+EnsureRegistered<IDomainService<Commerce.Order, Guid>>(services);
+EnsureRegistered<IRepository<Commerce.Catalog.Item, int>>(services);
+EnsureRegistered<IDomainService<Commerce.Catalog.Item, int>>(services);
+
+Console.WriteLine("Sample: NestedTypes - EF repository generator handles nested DbContext and entity types.");
+
+static void EnsureRegistered<TService>(IServiceCollection services)
+{
+	Ensure(services.Any(descriptor => descriptor.ServiceType == typeof(TService)), $"Missing service registration: {typeof(TService).FullName}");
+}
+
+static void Ensure(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}
+
+public static partial class Commerce
+{
+	public sealed class SalesDbContext(DbContextOptions<SalesDbContext> options) : SkywalkerDbContext<SalesDbContext>(options)
+	{
+		public DbSet<Order> Orders { get; set; } = default!;
+
+		public DbSet<Catalog.Item> CatalogItems { get; set; } = default!;
+	}
+
+	public sealed class Order : Entity<Guid>
+	{
+	}
+
+	public static partial class Catalog
+	{
+		public sealed class Item : Entity<int>
+		{
+		}
+	}
+}

--- a/samples/Skywalker.Sample.NestedTypes/Skywalker.Sample.NestedTypes.csproj
+++ b/samples/Skywalker.Sample.NestedTypes/Skywalker.Sample.NestedTypes.csproj
@@ -1,2 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+		<ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adds the fifth EF repository source generator sample required by Sprint 1.

Summary:
- Fills `Skywalker.Sample.NestedTypes` with a real EF repository SG smoke scenario.
- Exercises a nested `Commerce.SalesDbContext` and nested entity types including `Commerce.Catalog.Item`.
- Verifies generated registration metadata and repository/domain-service registrations at runtime.
- Updates the sample matrix, v2.0 roadmap, and changelog.
- The sample is already included in the `sg-quality` sample matrix, so CI will build and smoke-run it.

Validation:
- `dotnet build samples\Skywalker.Sample.NestedTypes\Skywalker.Sample.NestedTypes.csproj --no-restore -p:EnableSourceControlManagerQueries=false`
- `dotnet run --project samples\Skywalker.Sample.NestedTypes\Skywalker.Sample.NestedTypes.csproj --configuration Release -p:EnableSourceControlManagerQueries=false`
- `dotnet build Skywalker.sln --no-restore -p:EnableSourceControlManagerQueries=false`

Closes #242