### PR TITLE
Prepare preview 3 EF repository soak plan

### DIFF
--- a/docs/architecture/v2.0-preview.3-soak.md
+++ b/docs/architecture/v2.0-preview.3-soak.md
@@ -1,0 +1,76 @@
+# v2.0.0-preview.3 EF Repository SG Soak Plan
+
+> Status: Planned | Target: v2.0.0-preview.3 | Last updated: 2026-05-01
+
+This plan defines the release-readiness and soak checklist for the EF repository source generator work in Sprint 1. It prepares the preview.3 tag; it does not by itself authorize tagging.
+
+## Scope
+
+preview.3 is the first preview intended for seed-user validation of EF repository source generator adoption. It covers:
+
+- generated repository/domain-service registrations for `SkywalkerDbContext<TDbContext>` `DbSet<TEntity>` models
+- generated-first runtime bridge through `SkywalkerGeneratedRepositoryRegistrationAttribute`
+- non-AOT reflection fallback policy and AOT fallback-disabled behavior
+- diagnostics `SKY3001`-`SKY3006`
+- sample canaries: `Minimal`, `MultiDbContext`, `NestedTypes`, `LegacyMigration`, and `AspireAOT`
+
+## Release Readiness Checklist
+
+- [ ] `release/2.0` latest HEAD has green `Tests`, `Source Generator Quality`, and rolling package publish workflows.
+- [ ] `CHANGELOG.md` `[Unreleased]` entries are reviewed and ready to move into `2.0.0-preview.3`.
+- [ ] `dotnet test Skywalker.sln --configuration Release --no-build -m:1` passes on CI.
+- [ ] `sg-quality.yml` sample matrix passes, including `Skywalker.Sample.NestedTypes`.
+- [ ] `Skywalker.Sample.AspireAOT` publishes with `PublishAot=true` and no IL2xxx/IL3xxx warnings.
+- [ ] Public API check is green or any intentional API changes are captured in `PublicAPI.Unshipped.txt`.
+- [ ] Diagnostic docs for `SKY3001`-`SKY3006` are linked from `docs/diagnostics/README.md`.
+- [ ] Known limitations below are included in release notes.
+- [ ] Seed validation owners have the rolling package version and validation script.
+
+## Current Rolling Baseline
+
+As of 2026-05-01, `release/2.0` commit `0b90c8c1` is green for the preview.3 preparation gates:
+
+| Workflow | Run | Status |
+|---|---|---|
+| Tests | `25231618116` | Green |
+| Publish NuGet Packages | `25231618117` | Green |
+| Source Generator Quality | `25231618145` | Green, including sample matrix, Public API check, AOT publish canary, and pack alpha |
+
+Tagging still requires re-checking the final tag candidate commit immediately before creating `v2.0.0-preview.3`.
+
+## Seed Validation Targets
+
+| Target | Scenario | Validation goal |
+|---|---|---|
+| `Skywalker.Sample.Minimal` | Single DbContext, keyed and non-keyed entities | Confirm generated metadata and default repository/domain-service registrations. |
+| `Skywalker.Sample.MultiDbContext` | Two DbContexts in one app | Confirm generated registrars stay distinct and registrations do not cross-contaminate. |
+| `Skywalker.Sample.LegacyMigration` | Existing manual repository registration | Confirm generated defaults fill gaps without overwriting user registrations. |
+| `Skywalker.Sample.NestedTypes` | Nested DbContext and nested entity types | Confirm generated metadata and service registrations use fully qualified type names correctly. |
+| `Skywalker.Sample.AspireAOT` | NativeAOT registration contract canary | Confirm direct generated registrar path publishes without IL2xxx/IL3xxx warnings. |
+
+External seed users should validate at least three real projects before the preview.3 tag is announced:
+
+- a small single-DbContext application that can replace runtime default repository registration with generated metadata
+- a multi-DbContext application or module boundary that proves registrar name isolation
+- a migration candidate with at least one custom repository implementation that must keep precedence over generated defaults
+
+## Known Limitations
+
+- EF Core remains the rich ORM provider. preview.3 does not claim full EF Core NativeAOT readiness; that depends on EF Core and the selected provider.
+- NativeAOT-first persistence remains a v2.x provider track, planned around Dapper.AOT or ADO.NET.
+- Reflection fallback is retained only as a non-AOT compatibility path. NativeAOT/dynamic-code-disabled apps must use generated registration metadata or call generated registrars directly.
+- The generator only supports accessible concrete entity classes exposed by public instance `DbSet<TEntity>` properties.
+- Unsupported shapes are warnings, not errors, in preview.3. Consumers should treat `SKY3001`-`SKY3006` as migration blockers when preparing AOT-first apps.
+- The generator does not replace custom repositories; generated defaults use `TryAdd` semantics and should not overwrite existing registrations.
+
+## Migration Notes
+
+1. Add the EF repository source generator package/analyzer to the application project that owns the DbContext.
+2. Keep existing `services.AddSkywalkerDbContext<TDbContext>()` calls; the runtime bridge will prefer generated metadata when present.
+3. Review `SKY3001`-`SKY3006` warnings and fix unsupported `DbSet` or entity shapes before relying on generated output.
+4. For AOT/trimmed validation, set `Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback=true` and verify the app still starts.
+5. Keep manual repository registrations before `AddSkywalkerDbContext<TDbContext>()` when a custom implementation should win.
+
+## Tagging Gate
+
+Before creating `v2.0.0-preview.3`, record the exact `release/2.0` commit and workflow runs that are green. Do not tag while any required check is pending, failing, or skipped unexpectedly.

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -103,7 +103,7 @@ Slogan:
 - [x] 明确 EF AOT 支持边界：generated registration path AOT-friendly；full EF Core NativeAOT 取决于 EF Core/provider
 - [x] ≥ 5 个 SKYxxxx diagnostic + 文档页
 - [x] 明确 reflection fallback 的最终保留/移除策略：non-AOT compatibility only；NativeAOT/dynamic-code-disabled 场景缺失 generated metadata 时失败，不依赖 fallback
-- [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用
+- [ ] 发 `2.0.0-preview.3`，邀请 ≥ 3 个种子用户试用（soak plan: [`v2.0-preview.3-soak.md`](./v2.0-preview.3-soak.md)）
 - [ ] 浸泡 ≥ 2 周无 P0/P1，进入下一 sprint
 
 里程碑：**EF 模块零反射**。当前为 generated-first 过渡态；reflection fallback 仅作为 non-AOT 兼容路径保留。


### PR DESCRIPTION
Prepares the v2.0.0-preview.3 EF repository source generator soak plan.

Summary:
- Adds `docs/architecture/v2.0-preview.3-soak.md` with the preview.3 readiness checklist.
- Lists seed validation targets covering Minimal, MultiDbContext, LegacyMigration, NestedTypes, and AspireAOT.
- Documents external seed validation expectations, known limitations, migration notes, and the tagging gate.
- Records the current green `release/2.0` rolling baseline for commit `0b90c8c1`.
- Links the soak plan from the v2.0 roadmap.

Validation:
- Confirmed `release/2.0` commit `0b90c8c1` has green `Tests`, `Publish NuGet Packages`, and `Source Generator Quality` workflows.

No changelog needed: documentation-only release planning update.

Closes #243