### PR TITLE
Scaffold DynamicProxy source generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- DynamicProxy Source Generator preview.4 scaffolding：新增 analyzer-only `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目和 no-op 候选发现 smoke tests，为后续静态代理生成与 Castle.Core 移除做准备（#265）。
 - EF Repository registration 明确 reflection fallback 策略：generated registration 优先；fallback 仅作为 non-AOT 兼容路径保留，并可通过 AppContext switch 禁用以验证 AOT/trimmed 边界（#241）。
 - `Skywalker.Sample.NestedTypes` 填充为 EF repository source generator smoke sample，验证 nested DbContext/entity types 的 generated metadata 与 repository/domain-service 注册（#242）。
 - EF Repository Source Generator 新增 `SKY3001`-`SKY3006` 诊断，覆盖非 public `DbSet`、不可访问实体、缺少 `IEntity`、抽象实体、重复 `DbSet` 暴露和冲突 key type 推断等不支持场景，并补充对应诊断文档与测试（#239）。

--- a/Skywalker.sln
+++ b/Skywalker.sln
@@ -197,6 +197,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Sample.NestedType
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Ddd.EntityFrameworkCore.SourceGenerators", "src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj", "{958B0DF6-F576-459D-AAF9-BF45A04CE359}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Extensions.DynamicProxies.SourceGenerators", "src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj", "{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1311,6 +1313,18 @@ Global
 		{958B0DF6-F576-459D-AAF9-BF45A04CE359}.Release|x64.Build.0 = Release|Any CPU
 		{958B0DF6-F576-459D-AAF9-BF45A04CE359}.Release|x86.ActiveCfg = Release|Any CPU
 		{958B0DF6-F576-459D-AAF9-BF45A04CE359}.Release|x86.Build.0 = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|x64.Build.0 = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1410,6 +1424,7 @@ Global
 		{AAE9891F-E7D3-44AD-AF91-8F5B4B4833B0} = {54BB017B-1B7C-40C6-80FF-4499A62D1375}
 		{23303581-A8EE-4D08-84E8-9EB9E7DD7B03} = {54BB017B-1B7C-40C6-80FF-4499A62D1375}
 		{958B0DF6-F576-459D-AAF9-BF45A04CE359} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{6A6E1E8C-8CBD-433F-BEF4-88C4B9C236A5} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1448BD59-570D-4D37-831B-C0872E82B643}

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Skywalker.SourceGenerators;
+
+namespace Skywalker.Extensions.DynamicProxies.SourceGenerators;
+
+[Generator(LanguageNames.CSharp)]
+public sealed class DynamicProxyRegistrationGenerator : IIncrementalGenerator
+{
+    private const string InterceptableMetadataName = "Skywalker.Extensions.DynamicProxies.IInterceptable";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var candidates = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => node is ClassDeclarationSyntax,
+                static (context, _) => CreateModel(context.SemanticModel, (ClassDeclarationSyntax)context.Node))
+            .Where(static model => model is not null)
+            .Select(static (model, _) => model!.Value)
+            .Collect();
+
+        context.RegisterSourceOutput(candidates, static (_, _) => { });
+    }
+
+    private static InterceptableServiceModel? CreateModel(SemanticModel semanticModel, ClassDeclarationSyntax declaration)
+    {
+        if (semanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol
+            || !Implements(typeSymbol, InterceptableMetadataName))
+        {
+            return null;
+        }
+
+        return new InterceptableServiceModel(typeSymbol.GetFullyQualifiedName());
+    }
+
+    private static bool Implements(INamedTypeSymbol symbol, string metadataName)
+    {
+        return symbol.AllInterfaces.Any(type => type.OriginalDefinition.ToDisplayString() == metadataName);
+    }
+
+    private readonly struct InterceptableServiceModel : System.IEquatable<InterceptableServiceModel>
+    {
+        public InterceptableServiceModel(string serviceTypeName)
+        {
+            ServiceTypeName = serviceTypeName;
+        }
+
+        public string ServiceTypeName { get; }
+
+        public bool Equals(InterceptableServiceModel other)
+        {
+            return ServiceTypeName == other.ServiceTypeName;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InterceptableServiceModel other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return ServiceTypeName.GetHashCode();
+        }
+    }
+}

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/PublicAPI.Shipped.txt
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/PublicAPI.Unshipped.txt
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Skywalker.Extensions.DynamicProxies.SourceGenerators.DynamicProxyRegistrationGenerator
+Skywalker.Extensions.DynamicProxies.SourceGenerators.DynamicProxyRegistrationGenerator.DynamicProxyRegistrationGenerator() -> void
+Skywalker.Extensions.DynamicProxies.SourceGenerators.DynamicProxyRegistrationGenerator.Initialize(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context) -> void

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeSymbols>false</IncludeSymbols>
+    <IsPackable>true</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Skywalker.SourceGenerators.Common\EquatableArray.cs" Link="Skywalker.SourceGenerators.Common\EquatableArray.cs" />
+    <Compile Include="..\Skywalker.SourceGenerators.Common\SymbolExtensions.cs" Link="Skywalker.SourceGenerators.Common\SymbolExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Skywalker.SourceGenerators.Tests/DynamicProxyRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/DynamicProxyRegistrationGeneratorTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.CodeAnalysis;
+using Skywalker.Extensions.DynamicProxies;
+using Skywalker.Extensions.DynamicProxies.SourceGenerators;
+
+namespace Skywalker.SourceGenerators.Tests;
+
+public sealed class DynamicProxyRegistrationGeneratorTests
+{
+    [Fact]
+    public void ProducesNoSources_ForNoCandidateServices()
+    {
+        var result = GeneratorTestHelper.Run<DynamicProxyRegistrationGenerator>("""
+            namespace Demo;
+
+            public sealed class PlainService
+            {
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ProducesNoSources_ForInterceptableCandidateDuringScaffolding()
+    {
+        var result = GeneratorTestHelper.Run<DynamicProxyRegistrationGenerator>("""
+            using Skywalker.Extensions.DynamicProxies;
+
+            namespace Demo;
+
+            public interface IOrderService : IInterceptable
+            {
+                Task SubmitAsync();
+            }
+
+            public sealed class OrderService : IOrderService
+            {
+                public Task SubmitAsync() => Task.CompletedTask;
+            }
+            """, CreateReferences());
+
+        Assert.Empty(result.GeneratedTrees);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static IEnumerable<MetadataReference> CreateReferences()
+    {
+        yield return MetadataReference.CreateFromFile(typeof(IInterceptable).Assembly.Location);
+        yield return MetadataReference.CreateFromFile(typeof(Task).Assembly.Location);
+    }
+}

--- a/tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj
+++ b/tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" />
     <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj" />
+    <ProjectReference Include="..\..\src\Skywalker.Extensions.DynamicProxies\Skywalker.Extensions.DynamicProxies.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds the initial analyzer-only DynamicProxy source-generator package for v2.0-preview.4.

Summary:
- Adds `Skywalker.Extensions.DynamicProxies.SourceGenerators` with analyzer packaging settings aligned to the EF repository generator.
- Adds a no-op `DynamicProxyRegistrationGenerator` scaffold that discovers `IInterceptable` candidates without generating proxy code or changing runtime behavior yet.
- Adds PublicAPI tracking files and source-generator smoke tests.
- Adds the new generator project to `Skywalker.sln` and the source-generator test project references.

Validation:
- `dotnet build src/Skywalker.Extensions.DynamicProxies.SourceGenerators/Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj -p:EnableSourceControlManagerQueries=false -nologo`
- `dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj --filter DynamicProxyRegistrationGeneratorTests -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`
- `dotnet build Skywalker.sln -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`
- `dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`

Closes #265