### PR TITLE
Generate static DynamicProxy proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- DynamicProxy Source Generator preview.4 新增首版接口静态代理生成：为实现 `IInterceptable` 的 public/internal 服务生成同步与 Task/ValueTask 方法代理，并对暂不支持的方法签名报告 `SKY3101` 诊断（#266）。
 - DynamicProxy Source Generator preview.4 scaffolding：新增 analyzer-only `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目和 no-op 候选发现 smoke tests，为后续静态代理生成与 Castle.Core 移除做准备（#265）。
 - EF Repository registration 明确 reflection fallback 策略：generated registration 优先；fallback 仅作为 non-AOT 兼容路径保留，并可通过 AppContext switch 禁用以验证 AOT/trimmed 边界（#241）。
 - `Skywalker.Sample.NestedTypes` 填充为 EF repository source generator smoke sample，验证 nested DbContext/entity types 的 generated metadata 与 repository/domain-service 注册（#242）。

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -11,8 +11,9 @@ the diagnostic ID as the file name: `docs/diagnostics/SKYxxxx.md`.
 | Range | Area |
 |---|---|
 | `SKY1xxx` | DI and service registration |
-| `SKY2xxx` | DynamicProxy and interceptors |
-| `SKY3xxx` | EF Repository generation |
+| `SKY2xxx` | DynamicProxy runtime and interceptors |
+| `SKY300x` | EF Repository generation |
+| `SKY31xx` | DynamicProxy source generation |
 | `SKY4xxx` | EventBus handler generation |
 | `SKY5xxx` | Permission, localization, and settings generators |
 | `SKY9xxx` | Common source-generator diagnostics |
@@ -27,6 +28,12 @@ the diagnostic ID as the file name: `docs/diagnostics/SKYxxxx.md`.
 | `SKY3004` | Entity type must be a concrete class |
 | `SKY3005` | Entity type is exposed by multiple DbSet properties |
 | `SKY3006` | Entity key type inference is ambiguous |
+
+## DynamicProxy Source Generation
+
+| ID | Title |
+|---|---|
+| `SKY3101` | Intercepted service method signature is not supported |
 
 ## Required Page Structure
 

--- a/docs/diagnostics/SKY3101.md
+++ b/docs/diagnostics/SKY3101.md
@@ -1,0 +1,34 @@
+# SKY3101: Intercepted service method signature is not supported
+
+| Item | Value |
+|---|---|
+| Severity | Warning |
+| Introduced in | 2.0.0-preview.4 |
+| Category | Skywalker.Extensions.DynamicProxies.SourceGenerators |
+
+## Cause
+
+The DynamicProxy source generator found a method on an intercepted service interface that cannot be represented by the preview static proxy generator. Preview static proxies currently support ordinary non-generic instance methods with by-value parameters and these return shapes: `void`, synchronous values, `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>`.
+
+## Incorrect Example
+
+```csharp
+public interface IOrderService : IInterceptable
+{
+    void Update(ref int version);
+}
+```
+
+## Correct Example
+
+```csharp
+public interface IOrderService : IInterceptable
+{
+    int Update(int version);
+}
+```
+
+## Related Links
+
+- [DynamicProxy source generator contract](../architecture/dynamicproxy-sg-contract.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+SKY3101 | Skywalker.Extensions.DynamicProxies.SourceGenerators | Warning | Intercepted service method signature is not supported - see https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3101.md

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Skywalker.SourceGenerators;
@@ -9,29 +13,443 @@ namespace Skywalker.Extensions.DynamicProxies.SourceGenerators;
 public sealed class DynamicProxyRegistrationGenerator : IIncrementalGenerator
 {
     private const string InterceptableMetadataName = "Skywalker.Extensions.DynamicProxies.IInterceptable";
+    private const string Category = "Skywalker.Extensions.DynamicProxies.SourceGenerators";
+
+    private static readonly DiagnosticDescriptor UnsupportedMethodSignature = new(
+        id: "SKY3101",
+        title: "Intercepted service method signature is not supported",
+        messageFormat: "Method '{0}' on intercepted service interface '{1}' cannot be proxied by the DynamicProxy source generator: {2}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/dengxuan/Skywalker/blob/main/docs/diagnostics/SKY3101.md");
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var candidates = context.SyntaxProvider
+        var services = context.SyntaxProvider
             .CreateSyntaxProvider(
                 static (node, _) => node is ClassDeclarationSyntax,
                 static (context, _) => CreateModel(context.SemanticModel, (ClassDeclarationSyntax)context.Node))
             .Where(static model => model is not null)
-            .Select(static (model, _) => model!.Value)
-            .Collect();
+            .Select(static (model, _) => model!.Value);
 
-        context.RegisterSourceOutput(candidates, static (_, _) => { });
+        context.RegisterSourceOutput(services, static (context, model) => Generate(context, model));
     }
 
-    private static InterceptableServiceModel? CreateModel(SemanticModel semanticModel, ClassDeclarationSyntax declaration)
+    private static ServiceModel? CreateModel(SemanticModel semanticModel, ClassDeclarationSyntax declaration)
     {
-        if (semanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol
-            || !Implements(typeSymbol, InterceptableMetadataName))
+        if (semanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol implementation
+            || implementation.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal)
+            || !Implements(implementation, InterceptableMetadataName))
         {
             return null;
         }
 
-        return new InterceptableServiceModel(typeSymbol.GetFullyQualifiedName());
+        var proxies = ImmutableArray.CreateBuilder<ProxyModel>();
+        foreach (var serviceInterface in implementation.AllInterfaces
+            .Where(static type => type.OriginalDefinition.ToDisplayString() != InterceptableMetadataName)
+            .OrderBy(static type => type.GetFullyQualifiedName(), StringComparer.Ordinal))
+        {
+            var methods = ImmutableArray.CreateBuilder<MethodModel>();
+            var diagnostics = ImmutableArray.CreateBuilder<DiagnosticModel>();
+            foreach (var method in GetMethods(serviceInterface))
+            {
+                if (TryCreateMethod(method, serviceInterface, out var methodModel, out var diagnostic))
+                {
+                    methods.Add(methodModel!.Value);
+                }
+                else if (diagnostic is not null)
+                {
+                    diagnostics.Add(diagnostic.Value);
+                }
+            }
+
+            if (methods.Count > 0 || diagnostics.Count > 0)
+            {
+                proxies.Add(new ProxyModel(
+                    serviceInterface.GetFullyQualifiedName(),
+                    CreateProxyName(implementation, serviceInterface),
+                    new EquatableArray<MethodModel>(methods.ToImmutable()),
+                    new EquatableArray<DiagnosticModel>(diagnostics.ToImmutable())));
+            }
+        }
+
+        var proxyModels = proxies.ToImmutable();
+        return proxyModels.Length == 0
+            ? null
+            : new ServiceModel(implementation.GetFullyQualifiedName(), implementation.GetNamespace(), new EquatableArray<ProxyModel>(proxyModels));
+    }
+
+    private static IEnumerable<IMethodSymbol> GetMethods(INamedTypeSymbol serviceInterface)
+    {
+        foreach (var baseInterface in serviceInterface.Interfaces)
+        {
+            if (baseInterface.OriginalDefinition.ToDisplayString() == InterceptableMetadataName)
+            {
+                continue;
+            }
+
+            foreach (var method in GetMethods(baseInterface))
+            {
+                yield return method;
+            }
+        }
+
+        foreach (var method in serviceInterface.GetMembers().OfType<IMethodSymbol>())
+        {
+            if (method.MethodKind == MethodKind.Ordinary && !method.IsStatic)
+            {
+                yield return method;
+            }
+        }
+    }
+
+    private static bool TryCreateMethod(IMethodSymbol method, INamedTypeSymbol serviceInterface, out MethodModel? model, out DiagnosticModel? diagnostic)
+    {
+        model = null;
+        diagnostic = null;
+
+        if (method.TypeParameters.Length > 0)
+        {
+            diagnostic = CreateUnsupported(method, serviceInterface, "generic methods are deferred from preview.4 static proxy generation");
+            return false;
+        }
+
+        if (method.Parameters.Any(static parameter => parameter.RefKind != RefKind.None))
+        {
+            diagnostic = CreateUnsupported(method, serviceInterface, "ref, out, and in parameters are not supported");
+            return false;
+        }
+
+        var returnKind = GetReturnKind(method.ReturnType);
+        var parameters = method.Parameters
+            .Select(static parameter => new ParameterModel(parameter.Name, parameter.Type.GetFullyQualifiedName()))
+            .ToImmutableArray();
+
+        model = new MethodModel(
+            method.Name,
+            method.ReturnType.GetFullyQualifiedName(),
+            returnKind,
+            GetResultTypeName(method.ReturnType, returnKind),
+            CreateMethodFieldName(method),
+            new EquatableArray<ParameterModel>(parameters));
+        return true;
+    }
+
+    private static DiagnosticModel CreateUnsupported(IMethodSymbol method, INamedTypeSymbol serviceInterface, string reason)
+    {
+        return DiagnosticModel.Create(
+            UnsupportedMethodSignature,
+            method.Locations.FirstOrDefault(),
+            method.Name,
+            serviceInterface.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+            reason);
+    }
+
+    private static ReturnKind GetReturnKind(ITypeSymbol returnType)
+    {
+        if (returnType.SpecialType == SpecialType.System_Void)
+        {
+            return ReturnKind.Void;
+        }
+
+        if (returnType is INamedTypeSymbol namedType)
+        {
+            return namedType.OriginalDefinition.ToDisplayString() switch
+            {
+                "System.Threading.Tasks.Task" => ReturnKind.Task,
+                "System.Threading.Tasks.Task<TResult>" => ReturnKind.TaskOfT,
+                "System.Threading.Tasks.ValueTask" => ReturnKind.ValueTask,
+                "System.Threading.Tasks.ValueTask<TResult>" => ReturnKind.ValueTaskOfT,
+                _ => ReturnKind.SyncValue,
+            };
+        }
+
+        return ReturnKind.SyncValue;
+    }
+
+    private static string? GetResultTypeName(ITypeSymbol returnType, ReturnKind returnKind)
+    {
+        if (returnKind is not (ReturnKind.TaskOfT or ReturnKind.ValueTaskOfT)
+            || returnType is not INamedTypeSymbol namedType
+            || namedType.TypeArguments.Length != 1)
+        {
+            return null;
+        }
+
+        return namedType.TypeArguments[0].GetFullyQualifiedName();
+    }
+
+    private static void Generate(SourceProductionContext context, ServiceModel model)
+    {
+        foreach (var proxy in model.Proxies)
+        {
+            foreach (var diagnostic in proxy.Diagnostics)
+            {
+                context.ReportDiagnostic(diagnostic.Create());
+            }
+
+            if (proxy.Diagnostics.Length == 0 && proxy.Methods.Length > 0)
+            {
+                context.AddSource($"{proxy.Name}.SkywalkerDynamicProxy.g.cs", GenerateProxy(model, proxy));
+            }
+        }
+    }
+
+    private static string GenerateProxy(ServiceModel model, ProxyModel proxy)
+    {
+        var source = new StringBuilder();
+        source.AppendLine("// <auto-generated/>");
+        source.AppendLine("// This file was generated by Skywalker Source Generators.");
+        source.AppendLine("// Do not modify this file manually.");
+        source.AppendLine();
+        source.AppendLine("#nullable enable");
+        source.AppendLine("#pragma warning disable");
+        source.AppendLine();
+
+        if (!string.IsNullOrEmpty(model.Namespace))
+        {
+            source.Append("namespace ").Append(model.Namespace).AppendLine(";");
+            source.AppendLine();
+        }
+
+        source.Append("internal sealed class ").Append(proxy.Name).Append(" : ").AppendLine(proxy.ServiceTypeName);
+        source.AppendLine("{");
+        source.Append("    private readonly ").Append(model.ImplementationTypeName).AppendLine(" _target;");
+        source.Append("    private readonly ").Append(proxy.ServiceTypeName).AppendLine(" _service;");
+        source.AppendLine("    private readonly global::System.Collections.Generic.IReadOnlyList<global::Skywalker.Extensions.DynamicProxies.IInterceptor> _interceptors;");
+        source.AppendLine();
+        source.Append("    public ").Append(proxy.Name).Append('(').Append(model.ImplementationTypeName).AppendLine(" target, global::System.Collections.Generic.IEnumerable<global::Skywalker.Extensions.DynamicProxies.IInterceptor> interceptors)");
+        source.AppendLine("    {");
+        source.AppendLine("        _target = target ?? throw new global::System.ArgumentNullException(nameof(target));");
+        source.AppendLine("        _service = target;");
+        source.AppendLine("        _interceptors = global::System.Linq.Enumerable.ToArray(interceptors ?? throw new global::System.ArgumentNullException(nameof(interceptors)));");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        foreach (var method in proxy.Methods)
+        {
+            AppendMethodInfo(source, proxy, method);
+        }
+
+        source.AppendLine();
+        foreach (var method in proxy.Methods)
+        {
+            AppendMethod(source, method);
+            source.AppendLine();
+        }
+
+        AppendInvocation(source);
+        source.AppendLine("}");
+        return source.ToString();
+    }
+
+    private static void AppendMethodInfo(StringBuilder source, ProxyModel proxy, MethodModel method)
+    {
+        source.Append("    private static readonly global::System.Reflection.MethodInfo ").Append(method.MethodFieldName)
+            .Append(" = typeof(").Append(proxy.ServiceTypeName).Append(").GetMethod(\"").Append(method.Name).Append("\", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public, null, ");
+        AppendTypeArray(source, method);
+        source.AppendLine(", null)!;");
+    }
+
+    private static void AppendTypeArray(StringBuilder source, MethodModel method)
+    {
+        if (method.Parameters.Length == 0)
+        {
+            source.Append("global::System.Type.EmptyTypes");
+            return;
+        }
+
+        source.Append("new global::System.Type[] { ");
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                source.Append(", ");
+            }
+
+            source.Append("typeof(").Append(method.Parameters[i].TypeName).Append(')');
+        }
+
+        source.Append(" }");
+    }
+
+    private static void AppendMethod(StringBuilder source, MethodModel method)
+    {
+        source.Append("    public ").Append(method.ReturnTypeName).Append(' ').Append(method.Name).Append('(');
+        AppendParameters(source, method);
+        source.AppendLine(")");
+        source.AppendLine("    {");
+        source.Append("        var invocation = new SkywalkerGeneratedMethodInvocation(_target, ").Append(method.MethodFieldName).Append(", ");
+        AppendArguments(source, method);
+        source.AppendLine(", _interceptors, async generatedInvocation =>");
+        source.AppendLine("        {");
+        AppendTargetCall(source, method);
+        source.AppendLine("        });");
+
+        switch (method.ReturnKind)
+        {
+            case ReturnKind.Void:
+                source.AppendLine("        invocation.ProceedAsync().GetAwaiter().GetResult();");
+                source.AppendLine("        return;");
+                break;
+            case ReturnKind.SyncValue:
+                source.AppendLine("        invocation.ProceedAsync().GetAwaiter().GetResult();");
+                source.Append("        return (").Append(method.ReturnTypeName).AppendLine(")invocation.ReturnValue!;");
+                break;
+            case ReturnKind.Task:
+                source.AppendLine("        return invocation.ProceedAsync();");
+                break;
+            case ReturnKind.TaskOfT:
+                source.Append("        return AwaitResultAsync<").Append(method.ResultTypeName).AppendLine(">(invocation);");
+                break;
+            case ReturnKind.ValueTask:
+                source.AppendLine("        return new global::System.Threading.Tasks.ValueTask(invocation.ProceedAsync());");
+                break;
+            case ReturnKind.ValueTaskOfT:
+                source.Append("        return new global::System.Threading.Tasks.ValueTask<").Append(method.ResultTypeName).Append(">(AwaitResultAsync<").Append(method.ResultTypeName).AppendLine(">(invocation));");
+                break;
+        }
+
+        source.AppendLine("    }");
+    }
+
+    private static void AppendTargetCall(StringBuilder source, MethodModel method)
+    {
+        if (method.ReturnKind is ReturnKind.Void)
+        {
+            source.Append("            _service.").Append(method.Name).Append('(');
+            AppendArgumentNames(source, method);
+            source.AppendLine(");");
+            source.AppendLine("            await global::System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);");
+            return;
+        }
+
+        if (method.ReturnKind is ReturnKind.SyncValue)
+        {
+            source.Append("            generatedInvocation.ReturnValue = _service.").Append(method.Name).Append('(');
+            AppendArgumentNames(source, method);
+            source.AppendLine(");");
+            source.AppendLine("            await global::System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);");
+            return;
+        }
+
+        if (method.ReturnKind is ReturnKind.Task or ReturnKind.ValueTask)
+        {
+            source.Append("            await _service.").Append(method.Name).Append('(');
+            AppendArgumentNames(source, method);
+            source.AppendLine(").ConfigureAwait(false);");
+            return;
+        }
+
+        source.Append("            generatedInvocation.ReturnValue = await _service.").Append(method.Name).Append('(');
+        AppendArgumentNames(source, method);
+        source.AppendLine(").ConfigureAwait(false);");
+    }
+
+    private static void AppendParameters(StringBuilder source, MethodModel method)
+    {
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                source.Append(", ");
+            }
+
+            source.Append(method.Parameters[i].TypeName).Append(' ').Append(method.Parameters[i].Name);
+        }
+    }
+
+    private static void AppendArguments(StringBuilder source, MethodModel method)
+    {
+        if (method.Parameters.Length == 0)
+        {
+            source.Append("global::System.Array.Empty<object?>()");
+            return;
+        }
+
+        source.Append("new object?[] { ");
+        AppendArgumentNames(source, method);
+        source.Append(" }");
+    }
+
+    private static void AppendArgumentNames(StringBuilder source, MethodModel method)
+    {
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                source.Append(", ");
+            }
+
+            source.Append(method.Parameters[i].Name);
+        }
+    }
+
+    private static void AppendInvocation(StringBuilder source)
+    {
+        source.AppendLine("    private static async global::System.Threading.Tasks.Task<TResult> AwaitResultAsync<TResult>(SkywalkerGeneratedMethodInvocation invocation)");
+        source.AppendLine("    {");
+        source.AppendLine("        await invocation.ProceedAsync().ConfigureAwait(false);");
+        source.AppendLine("        return (TResult)invocation.ReturnValue!;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private sealed class SkywalkerGeneratedMethodInvocation : global::Skywalker.Extensions.DynamicProxies.IMethodInvocation");
+        source.AppendLine("    {");
+        source.AppendLine("        private readonly global::System.Collections.Generic.IReadOnlyList<global::Skywalker.Extensions.DynamicProxies.IInterceptor> _interceptors;");
+        source.AppendLine("        private readonly global::System.Func<SkywalkerGeneratedMethodInvocation, global::System.Threading.Tasks.Task> _target;");
+        source.AppendLine("        private int _index;");
+        source.AppendLine();
+        source.AppendLine("        public SkywalkerGeneratedMethodInvocation(object target, global::System.Reflection.MethodInfo method, object?[] arguments, global::System.Collections.Generic.IReadOnlyList<global::Skywalker.Extensions.DynamicProxies.IInterceptor> interceptors, global::System.Func<SkywalkerGeneratedMethodInvocation, global::System.Threading.Tasks.Task> targetInvoker)");
+        source.AppendLine("        {");
+        source.AppendLine("            Target = target;");
+        source.AppendLine("            Method = method;");
+        source.AppendLine("            Arguments = arguments;");
+        source.AppendLine("            ReturnType = method.ReturnType;");
+        source.AppendLine("            _interceptors = interceptors;");
+        source.AppendLine("            _target = targetInvoker;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        public object Target { get; }");
+        source.AppendLine("        public global::System.Reflection.MethodInfo Method { get; }");
+        source.AppendLine("        public string MethodName => Method.Name;");
+        source.AppendLine("        public object?[] Arguments { get; }");
+        source.AppendLine("        public global::System.Type ReturnType { get; }");
+        source.AppendLine("        public object? ReturnValue { get; set; }");
+        source.AppendLine("        public global::System.Threading.Tasks.Task ProceedAsync()");
+        source.AppendLine("        {");
+        source.AppendLine("            return _index < _interceptors.Count ? _interceptors[_index++].InterceptAsync(this) : _target(this);");
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+    }
+
+    private static string CreateProxyName(INamedTypeSymbol implementation, INamedTypeSymbol serviceInterface)
+    {
+        return $"{CreateIdentifier(implementation)}_{CreateIdentifier(serviceInterface)}SkywalkerProxy";
+    }
+
+    private static string CreateMethodFieldName(IMethodSymbol method)
+    {
+        var builder = new StringBuilder("s_").Append(method.Name);
+        foreach (var parameter in method.Parameters)
+        {
+            builder.Append('_').Append(CreateIdentifier(parameter.Type));
+        }
+
+        builder.Append("Method");
+        return builder.ToString();
+    }
+
+    private static string CreateIdentifier(ITypeSymbol symbol)
+    {
+        var displayName = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var builder = new StringBuilder(displayName.Length);
+        foreach (var character in displayName)
+        {
+            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        return builder.ToString().Trim('_');
     }
 
     private static bool Implements(INamedTypeSymbol symbol, string metadataName)
@@ -39,28 +457,133 @@ public sealed class DynamicProxyRegistrationGenerator : IIncrementalGenerator
         return symbol.AllInterfaces.Any(type => type.OriginalDefinition.ToDisplayString() == metadataName);
     }
 
-    private readonly struct InterceptableServiceModel : System.IEquatable<InterceptableServiceModel>
+    private static int CombineHash(params object?[] values)
     {
-        public InterceptableServiceModel(string serviceTypeName)
+        unchecked
+        {
+            var hash = 17;
+            foreach (var value in values)
+            {
+                hash = (hash * 31) + (value?.GetHashCode() ?? 0);
+            }
+
+            return hash;
+        }
+    }
+
+    private enum ReturnKind
+    {
+        Void,
+        SyncValue,
+        Task,
+        TaskOfT,
+        ValueTask,
+        ValueTaskOfT,
+    }
+
+    private readonly struct ServiceModel : IEquatable<ServiceModel>
+    {
+        public ServiceModel(string implementationTypeName, string @namespace, EquatableArray<ProxyModel> proxies)
+        {
+            ImplementationTypeName = implementationTypeName;
+            Namespace = @namespace;
+            Proxies = proxies;
+        }
+
+        public string ImplementationTypeName { get; }
+        public string Namespace { get; }
+        public EquatableArray<ProxyModel> Proxies { get; }
+        public bool Equals(ServiceModel other) => ImplementationTypeName == other.ImplementationTypeName && Namespace == other.Namespace && Proxies.Equals(other.Proxies);
+        public override bool Equals(object? obj) => obj is ServiceModel other && Equals(other);
+        public override int GetHashCode() => CombineHash(ImplementationTypeName, Namespace, Proxies);
+    }
+
+    private readonly struct ProxyModel : IEquatable<ProxyModel>
+    {
+        public ProxyModel(string serviceTypeName, string name, EquatableArray<MethodModel> methods, EquatableArray<DiagnosticModel> diagnostics)
         {
             ServiceTypeName = serviceTypeName;
+            Name = name;
+            Methods = methods;
+            Diagnostics = diagnostics;
         }
 
         public string ServiceTypeName { get; }
+        public string Name { get; }
+        public EquatableArray<MethodModel> Methods { get; }
+        public EquatableArray<DiagnosticModel> Diagnostics { get; }
+        public bool Equals(ProxyModel other) => ServiceTypeName == other.ServiceTypeName && Name == other.Name && Methods.Equals(other.Methods) && Diagnostics.Equals(other.Diagnostics);
+        public override bool Equals(object? obj) => obj is ProxyModel other && Equals(other);
+        public override int GetHashCode() => CombineHash(ServiceTypeName, Name, Methods, Diagnostics);
+    }
 
-        public bool Equals(InterceptableServiceModel other)
+    private readonly struct MethodModel : IEquatable<MethodModel>
+    {
+        public MethodModel(string name, string returnTypeName, ReturnKind returnKind, string? resultTypeName, string methodFieldName, EquatableArray<ParameterModel> parameters)
         {
-            return ServiceTypeName == other.ServiceTypeName;
+            Name = name;
+            ReturnTypeName = returnTypeName;
+            ReturnKind = returnKind;
+            ResultTypeName = resultTypeName;
+            MethodFieldName = methodFieldName;
+            Parameters = parameters;
         }
 
-        public override bool Equals(object? obj)
+        public string Name { get; }
+        public string ReturnTypeName { get; }
+        public ReturnKind ReturnKind { get; }
+        public string? ResultTypeName { get; }
+        public string MethodFieldName { get; }
+        public EquatableArray<ParameterModel> Parameters { get; }
+        public bool Equals(MethodModel other) => Name == other.Name && ReturnTypeName == other.ReturnTypeName && ReturnKind == other.ReturnKind && ResultTypeName == other.ResultTypeName && MethodFieldName == other.MethodFieldName && Parameters.Equals(other.Parameters);
+        public override bool Equals(object? obj) => obj is MethodModel other && Equals(other);
+        public override int GetHashCode() => CombineHash(Name, ReturnTypeName, ReturnKind, ResultTypeName, MethodFieldName, Parameters);
+    }
+
+    private readonly struct ParameterModel : IEquatable<ParameterModel>
+    {
+        public ParameterModel(string name, string typeName)
         {
-            return obj is InterceptableServiceModel other && Equals(other);
+            Name = name;
+            TypeName = typeName;
         }
 
-        public override int GetHashCode()
+        public string Name { get; }
+        public string TypeName { get; }
+        public bool Equals(ParameterModel other) => Name == other.Name && TypeName == other.TypeName;
+        public override bool Equals(object? obj) => obj is ParameterModel other && Equals(other);
+        public override int GetHashCode() => CombineHash(Name, TypeName);
+    }
+
+    private readonly struct DiagnosticModel : IEquatable<DiagnosticModel>
+    {
+        private DiagnosticModel(DiagnosticDescriptor descriptor, Location? location, EquatableArray<string> messageArgs)
         {
-            return ServiceTypeName.GetHashCode();
+            Descriptor = descriptor;
+            Location = location;
+            MessageArgs = messageArgs;
         }
+
+        public DiagnosticDescriptor Descriptor { get; }
+        public Location? Location { get; }
+        public EquatableArray<string> MessageArgs { get; }
+
+        public static DiagnosticModel Create(DiagnosticDescriptor descriptor, Location? location, params string[] messageArgs)
+        {
+            return new DiagnosticModel(descriptor, location, new EquatableArray<string>(messageArgs));
+        }
+
+        public Diagnostic Create()
+        {
+            return Diagnostic.Create(Descriptor, Location, MessageArgs.AsImmutableArray().Cast<object>().ToArray());
+        }
+
+        public bool Equals(DiagnosticModel other)
+        {
+            return Descriptor.Id == other.Descriptor.Id && MessageArgs.Equals(other.MessageArgs);
+        }
+
+        public override bool Equals(object? obj) => obj is DiagnosticModel other && Equals(other);
+        public override int GetHashCode() => CombineHash(Descriptor.Id, MessageArgs);
     }
 }

--- a/tests/Skywalker.SourceGenerators.Tests/DynamicProxyRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/DynamicProxyRegistrationGeneratorTests.cs
@@ -22,7 +22,49 @@ public sealed class DynamicProxyRegistrationGeneratorTests
     }
 
     [Fact]
-    public void ProducesNoSources_ForInterceptableCandidateDuringScaffolding()
+    public void GeneratesProxy_ForInterceptableInterfaceService()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using System.Threading.Tasks;
+            using Skywalker.Extensions.DynamicProxies;
+
+            namespace Demo;
+
+            public interface IOrderService : IInterceptable
+            {
+                void Touch(int id);
+                int Count();
+                Task SubmitAsync();
+                Task<string> GetNameAsync(int id);
+                ValueTask FlushAsync();
+                ValueTask<int> GetCountAsync();
+            }
+
+            public sealed class OrderService : IOrderService
+            {
+                public void Touch(int id) { }
+                public int Count() => 42;
+                public Task SubmitAsync() => Task.CompletedTask;
+                public Task<string> GetNameAsync(int id) => Task.FromResult(id.ToString());
+                public ValueTask FlushAsync() => ValueTask.CompletedTask;
+                public ValueTask<int> GetCountAsync() => ValueTask.FromResult(42);
+            }
+            """, new DynamicProxyRegistrationGenerator(), CreateReferences());
+
+        var generatedTree = Assert.Single(result.GeneratedTrees);
+        var generatedSource = generatedTree.GetText().ToString();
+
+        Assert.EndsWith("SkywalkerProxy.SkywalkerDynamicProxy.g.cs", generatedTree.FilePath);
+        Assert.Contains("internal sealed class", generatedSource);
+        Assert.Contains(": global::Demo.IOrderService", generatedSource);
+        Assert.Contains("Touch(", generatedSource);
+        Assert.Contains("GetNameAsync(", generatedSource);
+        Assert.Empty(result.Diagnostics);
+        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForRefParameter()
     {
         var result = GeneratorTestHelper.Run<DynamicProxyRegistrationGenerator>("""
             using Skywalker.Extensions.DynamicProxies;
@@ -31,17 +73,19 @@ public sealed class DynamicProxyRegistrationGeneratorTests
 
             public interface IOrderService : IInterceptable
             {
-                Task SubmitAsync();
+                void Touch(ref int id);
             }
 
             public sealed class OrderService : IOrderService
             {
-                public Task SubmitAsync() => Task.CompletedTask;
+                public void Touch(ref int id) { }
             }
             """, CreateReferences());
 
         Assert.Empty(result.GeneratedTrees);
-        Assert.Empty(result.Diagnostics);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("SKY3101", diagnostic.Id);
+        Assert.Contains("ref, out, and in parameters are not supported", diagnostic.GetMessage());
     }
 
     private static IEnumerable<MetadataReference> CreateReferences()

--- a/tests/Skywalker.SourceGenerators.Tests/GeneratorTestHelper.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/GeneratorTestHelper.cs
@@ -37,6 +37,25 @@ public static class GeneratorTestHelper
         return driver.GetRunResult();
     }
 
+    public static (GeneratorDriverRunResult RunResult, Compilation Compilation) RunWithCompilation(
+        string source,
+        IIncrementalGenerator generator,
+        IEnumerable<MetadataReference>? references = null,
+        CSharpCompilationOptions? compilationOptions = null)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, ParseOptions);
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Skywalker.SourceGenerator.Tests.Target",
+            syntaxTrees: [syntaxTree],
+            references: CreateReferences(references),
+            options: compilationOptions ?? CreateCompilationOptions());
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+
+        return (driver.GetRunResult(), updatedCompilation);
+    }
+
     public static ImmutableArray<Diagnostic> GetCompilationDiagnostics(
         string source,
         IEnumerable<MetadataReference>? references = null,


### PR DESCRIPTION
Adds the first DynamicProxy source generator implementation for #266.

Summary:
- Generate internal static interface proxies for public/internal `IInterceptable` service implementations.
- Support `void`, sync value, `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>` method shapes.
- Report `SKY3101` for unsupported preview method signatures such as `ref`/`out`/`in` parameters and document the diagnostic.
- Add compilation-aware generator test coverage and changelog entry.

Validation:
- `dotnet test tests\Skywalker.SourceGenerators.Tests\Skywalker.SourceGenerators.Tests.csproj -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`
- `dotnet build Skywalker.sln -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`

Refs #266