### PR TITLE
Add DynamicProxy AOT canary coverage

### DIFF
--- a/.github/workflows/sg-quality.yml
+++ b/.github/workflows/sg-quality.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Build EF repository generator analyzer
         run: dotnet build src/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators/Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj --configuration Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:ContinuousIntegrationBuild=false
 
+      - name: Build DynamicProxy generator analyzer
+        run: dotnet build src/Skywalker.Extensions.DynamicProxies.SourceGenerators/Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj --configuration Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:ContinuousIntegrationBuild=false
+
       - name: Publish AOT sample
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- `Skywalker.Sample.AspireAOT` 扩展为 DynamicProxy Source Generator AOT canary：在 NativeAOT publish gate 中同时验证 EF repository generated registration 与 DynamicProxy generated static proxy/interceptor 路径零 IL2xxx/IL3xxx warning（#268）。
 - DynamicProxy Source Generator preview.4 测试安全网：新增 50 个静态代理 snapshot 场景、generated proxy DI runtime 覆盖，并让 `AddInterceptedServices()` 优先使用生成代理元数据，Castle 继续作为兼容 fallback（#267）。
 - DynamicProxy Source Generator preview.4 新增首版接口静态代理生成：为实现 `IInterceptable` 的 public/internal 服务生成同步与 Task/ValueTask 方法代理，并对暂不支持的方法签名报告 `SKY3101` 诊断（#266）。
 - DynamicProxy Source Generator preview.4 scaffolding：新增 analyzer-only `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目和 no-op 候选发现 smoke tests，为后续静态代理生成与 Castle.Core 移除做准备（#265）。

--- a/samples/README.md
+++ b/samples/README.md
@@ -24,7 +24,7 @@ is added to both places and can pass build/run smoke validation.
 | `Skywalker.Sample.NestedTypes` | Nested DbContext/entity types and fully-qualified generated names | Sprint 1 smoke test: generated metadata + repository/domain-service registration for nested types | Sprint 1, Sprint 3 |
 | `Skywalker.Sample.InternalServices` | `internal` service types generated in the same assembly | Skeleton, build/run smoke test | Sprint 3 |
 | `Skywalker.Sample.Modular` | Cross-assembly module discovery and registration | Skeleton, single-project placeholder | Sprint 3 |
-| `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Sprint 1 smoke test: EF repository generator direct-call contract publishes with no IL2xxx/IL3xxx warnings | Sprint 1+ |
+| `Skywalker.Sample.AspireAOT` | NativeAOT publish canary | Sprint 2 smoke test: EF repository generated registration plus DynamicProxy generated static proxies publish with no IL2xxx/IL3xxx warnings | Sprint 1+ |
 | `Skywalker.Sample.LegacyMigration` | v1.x manual registration coexisting with v2.0 SG registration | Sprint 1 smoke test: manual keyed repository registration survives generated defaults | Sprint 1, Sprint 5 |
 
 `Skywalker.Sample.RealWorldShop` is intentionally out of this Sprint 0 matrix and

--- a/samples/Skywalker.Sample.AspireAOT/Program.cs
+++ b/samples/Skywalker.Sample.AspireAOT/Program.cs
@@ -1,18 +1,48 @@
 using Microsoft.Extensions.DependencyInjection;
 using Skywalker.Ddd.Domain.Repositories;
 using Skywalker.Ddd.Domain.Services;
+using Skywalker.Extensions.DynamicProxies;
 using Skywalker.Identity.Domain.Repositories;
 using Skywalker.Sample.AspireAOT;
 
 var services = new ServiceCollection();
 global::Microsoft.Extensions.DependencyInjection.Skywalker_Sample_AspireAOT_AotDbContextSkywalkerRepositoryRegistrations.AddSkywalkerGeneratedRepositoriesForSkywalker_Sample_AspireAOT_AotDbContext(services);
+services.AddSingleton<CallRecorder>();
+services.AddSingleton<IInterceptor, RecordingInterceptor>();
+services.AddSingleton<AotOrderService>();
+services.AddSingleton<AotStringLookupService>();
 
 EnsureRegistered<IRepository<AotOrder, Guid>, Repository<AotDbContext, AotOrder, Guid>>(services);
 EnsureRegistered<IRepository<AotOrder>, Repository<AotDbContext, AotOrder, Guid>>(services);
 EnsureRegistered<IDomainService<AotOrder, Guid>, EntityFrameworkCoreDomainService<AotOrder, Guid>>(services);
 EnsureRegistered<IDomainService<AotOrder>, EntityFrameworkCoreDomainService<AotOrder, Guid>>(services);
 
-Console.WriteLine("Sample: AspireAOT — EF repository source generator registration verified.");
+using var provider = services.BuildServiceProvider();
+var interceptors = provider.GetServices<IInterceptor>();
+var orderProxy = new global__Skywalker_Sample_AspireAOT_AotOrderService_global__Skywalker_Sample_AspireAOT_IAotOrderServiceSkywalkerProxy(
+	provider.GetRequiredService<AotOrderService>(),
+	interceptors);
+var lookupProxy = new global__Skywalker_Sample_AspireAOT_AotStringLookupService_global__Skywalker_Sample_AspireAOT_IAotLookupService_stringSkywalkerProxy(
+	provider.GetRequiredService<AotStringLookupService>(),
+	interceptors);
+
+var orderResult = await orderProxy.SubmitAsync("AOT-001");
+var lookupResult = lookupProxy.Echo("edge");
+var recorder = provider.GetRequiredService<CallRecorder>();
+
+Ensure(orderResult == "submitted:AOT-001", "DynamicProxy generated async proxy returned an unexpected value.");
+Ensure(lookupResult == "edge", "DynamicProxy generated closed generic proxy returned an unexpected value.");
+Ensure(
+	recorder.Entries.SequenceEqual(new[]
+	{
+		"before:SubmitAsync:AOT-001",
+		"after:SubmitAsync:submitted:AOT-001",
+		"before:Echo:edge",
+		"after:Echo:edge",
+	}),
+	"DynamicProxy generated proxy interceptor order was not preserved.");
+
+Console.WriteLine("Sample: AspireAOT — EF repository and DynamicProxy source generator paths verified.");
 
 static void EnsureRegistered<TService, TImplementation>(IServiceCollection services)
 {
@@ -38,6 +68,90 @@ namespace Skywalker.Sample.AspireAOT
 
 	public sealed class AotOrder : Skywalker.Ddd.Domain.Entities.Entity<Guid>
 	{
+	}
+
+	public interface IAotOrderService : Skywalker.Extensions.DynamicProxies.IInterceptable
+	{
+		Task<string> SubmitAsync(string number);
+	}
+
+	public sealed class AotOrderService : IAotOrderService
+	{
+		public Task<string> SubmitAsync(string number)
+		{
+			return Task.FromResult($"submitted:{number}");
+		}
+	}
+
+	public interface IAotLookupService<T> : Skywalker.Extensions.DynamicProxies.IInterceptable
+	{
+		T Echo(T value);
+	}
+
+	public sealed class AotStringLookupService : IAotLookupService<string>
+	{
+		public string Echo(string value) => value;
+	}
+
+	public sealed class CallRecorder
+	{
+		private readonly List<string> _entries = [];
+
+		public IReadOnlyList<string> Entries => _entries;
+
+		public void Add(string entry)
+		{
+			_entries.Add(entry);
+		}
+	}
+
+	public sealed class RecordingInterceptor(CallRecorder recorder) : Skywalker.Extensions.DynamicProxies.IInterceptor
+	{
+		public async Task InterceptAsync(Skywalker.Extensions.DynamicProxies.IMethodInvocation invocation)
+		{
+			recorder.Add($"before:{invocation.MethodName}:{invocation.Arguments[0]}");
+			await invocation.ProceedAsync().ConfigureAwait(false);
+			recorder.Add($"after:{invocation.MethodName}:{invocation.ReturnValue}");
+		}
+	}
+}
+
+namespace Skywalker.Extensions.DynamicProxies
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class SkywalkerGeneratedDynamicProxyAttribute(Type serviceType, Type implementationType, Type proxyType) : Attribute
+	{
+		public Type ServiceType { get; } = serviceType;
+
+		public Type ImplementationType { get; } = implementationType;
+
+		public Type ProxyType { get; } = proxyType;
+	}
+
+	public interface IInterceptable
+	{
+	}
+
+	public interface IInterceptor
+	{
+		Task InterceptAsync(IMethodInvocation invocation);
+	}
+
+	public interface IMethodInvocation
+	{
+		object Target { get; }
+
+		System.Reflection.MethodInfo Method { get; }
+
+		string MethodName { get; }
+
+		object?[] Arguments { get; }
+
+		Type ReturnType { get; }
+
+		object? ReturnValue { get; set; }
+
+		Task ProceedAsync();
 	}
 }
 

--- a/samples/Skywalker.Sample.AspireAOT/README.md
+++ b/samples/Skywalker.Sample.AspireAOT/README.md
@@ -7,12 +7,16 @@ this sample's `dotnet publish -p:PublishAot=true` succeeding with **zero warning
 
 - `dotnet publish -p:PublishAot=true` produces a native binary
 - No `IL2xxx` (trim) or `IL3xxx` (AOT) warnings — generated code is reflection-free
+- EF repository generated registration can be called directly without runtime scanning
+- DynamicProxy generated static proxies execute registered interceptors without Castle or runtime IL emit
 - Output binary is small and starts fast
 
-## Current state (Sprint 0)
+## Current state
 
-Skeleton. Currently only validates that `PublishAot=true` doesn't outright fail.
-Warning-free publish is the bar for Sprint 1+ once each SG lands its AOT story.
+This sample is an active source-generator AOT canary. It exercises the EF repository
+generated registrar and the DynamicProxy generated static proxy path in one small
+console app so `sg-quality.yml` can publish it as a NativeAOT binary and fail on any
+`IL2xxx` / `IL3xxx` warning.
 
 ## Verify locally
 
@@ -23,5 +27,5 @@ dotnet publish samples/Skywalker.Sample.AspireAOT -p:PublishAot=true -c Release
 ## Filled in by
 
 - **Sprint 1 (EF Repository SG)** — first SG-generated code participates in AOT publish
-- **Sprint 2 (DynamicProxy SG + Castle removal)** — major reflection elimination
+- **Sprint 2 (DynamicProxy SG + Castle removal)** — generated static proxy path participates in AOT publish
 - **Sprint 5 (release)** — strict warning-as-error gate

--- a/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
+++ b/samples/Skywalker.Sample.AspireAOT/Skywalker.Sample.AspireAOT.csproj
@@ -22,10 +22,12 @@
 
   <ItemGroup Condition="'$(PublishAot)' != 'true'">
     <ProjectReference Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="EnableSourceLink=false;EnableSourceControlManagerQueries=false;PublishRepositoryUrl=false;EmbedUntrackedSources=false;ContinuousIntegrationBuild=false" />
+    <ProjectReference Include="..\..\src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="EnableSourceLink=false;EnableSourceControlManagerQueries=false;PublishRepositoryUrl=false;EmbedUntrackedSources=false;ContinuousIntegrationBuild=false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <Analyzer Include="..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.dll" />
+    <Analyzer Include="..\..\src\Skywalker.Extensions.DynamicProxies.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Extensions.DynamicProxies.SourceGenerators.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds DynamicProxy source-generator coverage to the existing AspireAOT canary so the NativeAOT publish gate exercises generated static proxies alongside the EF repository generated registrar.

Summary:
- Extends `Skywalker.Sample.AspireAOT` with generated DynamicProxy static proxy smoke coverage.
- Covers a registered interceptor, an async service method, and a closed generic service interface edge case.
- Builds the DynamicProxy source generator analyzer before the AOT publish gate in `sg-quality.yml`.
- Updates the sample docs and changelog for the Sprint 2 AOT canary.

Validation:
- `dotnet build samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj -p:EnableSourceControlManagerQueries=false -nologo -v minimal`
- `dotnet run --project samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj -p:EnableSourceControlManagerQueries=false --no-build`
- `dotnet build src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj --configuration Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:ContinuousIntegrationBuild=false -nologo -v minimal`
- `dotnet build src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj --configuration Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:ContinuousIntegrationBuild=false -nologo -v minimal`
- `dotnet publish samples\Skywalker.Sample.AspireAOT\Skywalker.Sample.AspireAOT.csproj --configuration Release -p:PublishAot=true -p:EnableSourceControlManagerQueries=false -nologo -v minimal`
- NativeAOT published exe smoke run
- `dotnet build Skywalker.sln -p:EnableSourceControlManagerQueries=false -nologo -v minimal -clp:ErrorsOnly`

Refs #268