### PR TITLE
Document DynamicProxy migration diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- DynamicProxy Source Generator preview.4 迁移与诊断文档：补全 Castle → source-generated static proxy 的 before/after、支持/限制清单、`SKY3101` 修复指南和 preview.4 readiness 链接（#270）。
 - DynamicProxies v2.0 移除 Castle.Core runtime fallback：`AddInterceptedServices()` 现在只接受 source-generated static proxy metadata，缺少 generated proxy 的 legacy Castle-only 注册会给出明确迁移错误（#269）。
 - `Skywalker.Sample.AspireAOT` 扩展为 DynamicProxy Source Generator AOT canary：在 NativeAOT publish gate 中同时验证 EF repository generated registration 与 DynamicProxy generated static proxy/interceptor 路径零 IL2xxx/IL3xxx warning（#268）。
 - DynamicProxy Source Generator preview.4 测试安全网：新增 50 个静态代理 snapshot 场景、generated proxy DI runtime 覆盖，并让 `AddInterceptedServices()` 优先使用生成代理元数据，Castle 继续作为兼容 fallback（#267）。

--- a/docs/architecture/v2.0-preview.4-dynamicproxy-readiness.md
+++ b/docs/architecture/v2.0-preview.4-dynamicproxy-readiness.md
@@ -1,0 +1,44 @@
+# v2.0.0-preview.4 DynamicProxy Readiness
+
+> Status: Draft readiness note for the DynamicProxy SG preview track  
+> Tracking: #253, #270
+
+## Scope
+
+Preview.4 makes the supported DynamicProxy path source-generated static interface proxies. It removes the Castle.Core runtime dependency and keeps the existing `IInterceptor` / `IMethodInvocation` authoring model for supported service shapes.
+
+## Ready In This Track
+
+- `Skywalker.Extensions.DynamicProxies.SourceGenerators` ships as an analyzer-only generator package.
+- Public and internal intercepted implementations can generate static interface proxies.
+- Generated proxies cover sync values, `void`, `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`, overloads, inherited interface methods, and closed generic service interfaces.
+- `AddInterceptedServices()` uses generated proxy metadata and no longer falls back to Castle.DynamicProxy.
+- `Skywalker.Sample.AspireAOT` validates generated DynamicProxy usage in the NativeAOT publish canary.
+- Runtime tests cover generated proxy DI replacement, interceptor ordering, proceed behavior, return values, and non-intercepted service behavior.
+- Package dependency inspection confirms `Skywalker.Extensions.DynamicProxies` no longer depends on `Castle.Core`.
+
+## Migration Links
+
+- [DynamicProxy migration guide](../migration/v1-to-v2.md#31-castledynamicproxy--source-generated-static-proxies)
+- [DynamicProxy source generator contract](dynamicproxy-sg-contract.md)
+- [SKY3101 diagnostic](../diagnostics/SKY3101.md)
+- [AspireAOT canary sample](../../samples/Skywalker.Sample.AspireAOT/README.md)
+
+## Known Limitations
+
+- Class-only proxying is not part of preview.4. Use interface service registrations.
+- Generic methods are deferred. Prefer closed generic service interfaces.
+- `ref`, `out`, and `in` parameters are not supported.
+- Factory and instance registrations cannot be proxied when the implementation type is not available at compile time.
+- Strongly typed `[Intercept<TInterceptor>]` filtering remains a follow-up item.
+
+## Release Gate Checklist
+
+- [x] DynamicProxy generator project exists and is packed as analyzer-only.
+- [x] Static proxy generation is covered by snapshot tests.
+- [x] Runtime DI replacement is covered by tests.
+- [x] AOT canary validates generated proxy usage with no proxy-related `IL2xxx` / `IL3xxx` warnings.
+- [x] Castle.Core dependency is removed from `Skywalker.Extensions.DynamicProxies`.
+- [x] Migration guide documents before/after usage and unsupported legacy behavior.
+- [x] DynamicProxy diagnostics link to docs pages.
+- [ ] Strongly typed interceptor API is designed and implemented in a follow-up issue.

--- a/docs/architecture/v2.0-roadmap.md
+++ b/docs/architecture/v2.0-roadmap.md
@@ -110,7 +110,7 @@ Slogan:
 
 ### Sprint 2（DynamicProxy SG + 移除 Castle）—— 3 周
 
-v2.0 核心战役。设计契约见 [`dynamicproxy-sg-contract.md`](./dynamicproxy-sg-contract.md)（#264）。
+v2.0 核心战役。设计契约见 [`dynamicproxy-sg-contract.md`](./dynamicproxy-sg-contract.md)（#264），preview.4 readiness 见 [`v2.0-preview.4-dynamicproxy-readiness.md`](./v2.0-preview.4-dynamicproxy-readiness.md)。
 
 - [x] `Skywalker.Extensions.DynamicProxies.SourceGenerators` 项目（替换 v1 阶段的混合实现）
 - [x] 编译期生成静态代理类
@@ -177,7 +177,7 @@ v1.x → v2.0 的破坏性变更：
 
 | # | 变更 | 影响 | 迁移方案 | 状态 |
 |---|---|---|---|---|
-| 1 | 移除 `Castle.Core` | 直接使用 Castle API 的代码 | 用 `[Intercept<T>]` | 待 Sprint 2 |
+| 1 | 移除 `Castle.Core` | 直接使用 Castle API 的代码 | 使用 DynamicProxy source generator 覆盖的 interface proxy shape | ✅ preview.4 track |
 | 2 | `IInterceptable` 标注 → SG 标注 | 实现该接口的服务 | 加 `partial`，标 `[ApplicationService]` | 待 Sprint 2/3 |
 | 3 | `AddInterceptedServices()` 删除 | Program.cs | 改用 `AddSkywalker()` | 待 Sprint 3 |
 | 4 | AppService 无需继承基类 | （无强制破坏，向后兼容） | 可选迁移 | 待 Sprint 3 |

--- a/docs/diagnostics/SKY3101.md
+++ b/docs/diagnostics/SKY3101.md
@@ -8,7 +8,15 @@
 
 ## Cause
 
-The DynamicProxy source generator found a method on an intercepted service interface that cannot be represented by the preview static proxy generator. Preview static proxies currently support ordinary non-generic instance methods with by-value parameters and these return shapes: `void`, synchronous values, `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>`.
+The DynamicProxy source generator found a method on an intercepted service interface that cannot be represented by the preview.4 static proxy generator.
+
+Preview.4 static proxies currently support ordinary non-generic instance methods with by-value parameters and these return shapes: `void`, synchronous values, `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>`.
+
+The most common causes are:
+
+- A generic method, such as `T Echo<T>(T value)`.
+- A `ref`, `out`, or `in` parameter.
+- A service contract that still expects Castle.DynamicProxy runtime behavior.
 
 ## Incorrect Example
 
@@ -16,6 +24,13 @@ The DynamicProxy source generator found a method on an intercepted service inter
 public interface IOrderService : IInterceptable
 {
     void Update(ref int version);
+}
+```
+
+```csharp
+public interface IOrderService : IInterceptable
+{
+    T Echo<T>(T value);
 }
 ```
 
@@ -27,6 +42,27 @@ public interface IOrderService : IInterceptable
     int Update(int version);
 }
 ```
+
+For generic behavior, move the type parameter to the service interface so the consuming project closes the generic service shape at compile time:
+
+```csharp
+public interface IEntityEchoService<T> : IInterceptable
+{
+    T Echo(T value);
+}
+
+public sealed class StringEchoService : IEntityEchoService<string>
+{
+    public string Echo(string value) => value;
+}
+```
+
+## Fix Guidance
+
+1. Replace `ref`, `out`, and `in` parameters with by-value request/response models.
+2. Replace generic methods with closed generic service interfaces where possible.
+3. Keep unsupported methods out of `IInterceptable` service contracts until the generator supports them.
+4. Confirm the consuming project references `Skywalker.Extensions.DynamicProxies.SourceGenerators` as an analyzer.
 
 ## Related Links
 

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -94,22 +94,110 @@ builder.Services.AddSkywalker<Startup>(cfg =>
 
 ## 3. DynamicProxy 拦截器
 
-### 3.1 Castle.DynamicProxy → SG 静态代理
+### 3.1 Castle.DynamicProxy → Source-generated static proxies
 
-**状态**：规划中（Sprint 2，v2.0 最大单体工作量）
+**状态**：✅ 已落地（preview.4 track，#264-#270）
 
-**现象**：v1.x 依赖 `Castle.Core` (~600 KB) 在运行时 IL Emit 代理类，AOT 不友好。
+**现象**：v1.x 依赖 `Castle.Core` (~600 KB) 在运行时 IL Emit 代理类，AOT 不友好。v1.x 中只要服务实现 `IInterceptable`，`AddInterceptedServices()` 就会尝试用 Castle 在运行时创建接口代理或类代理。
 
-**v2.0 目标**：
-- 完全移除 `Castle.Core` 依赖。
-- `AddInterceptedServices()` 仅支持 source-generated interface proxy metadata；缺少生成代理的 legacy Castle-only 注册会在启动期给出迁移错误。
-- 由 SG 在编译期生成静态代理类型。
-- 新 API：`[Intercept<TInterceptor>]` 强类型拦截器标注。
+**原因**：v2.0 的 DynamicProxy 支持路径改为编译期生成静态代理。这样可以移除 `Castle.Core` 传递依赖、避免运行时 IL Emit，并让 NativeAOT publish gate 能验证代理路径。
 
-**迁移步骤**（占位）：
-- [ ] 自定义 `IAsyncInterceptor` 实现的迁移
-- [ ] 异步 / 泛型 / `ref`-`out` 方法的 edge case
-- [ ] AOT publish 零警告验证方法
+**v2.0 行为**：
+- `Castle.Core`、`CastleProxyGenerator`、`IProxyGenerator` 已从 `Skywalker.Extensions.DynamicProxies` 移除。
+- `AddDynamicProxies()` 保留为兼容 no-op，不再注册运行时代理工厂。
+- `AddInterceptedServices()` 只会在找到 source-generated proxy metadata 时替换服务注册。
+- 对带有可拦截接口方法、但缺少 generated proxy metadata 的 legacy Castle-only 注册，启动期会抛出明确迁移错误。
+- 对没有接口方法的 marker registration，保持原注册，避免 DDD 自动注册中的空 marker 接口被误判为需要代理。
+
+#### 必需项目引用
+
+消费项目需要同时引用 runtime 包和 source generator analyzer。项目引用写法如下；NuGet 使用时 generator 包也应作为 analyzer/private asset 引入。
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Skywalker.Extensions.DynamicProxies" Version="2.0.0-preview.*" />
+  <PackageReference Include="Skywalker.Extensions.DynamicProxies.SourceGenerators" Version="2.0.0-preview.*" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+仓库内项目引用示例：
+
+```xml
+<ProjectReference Include="..\..\src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+```
+
+#### Before: v1.x Castle-backed interception
+
+```csharp
+public interface IOrderService : IInterceptable
+{
+    Task<string> SubmitAsync(string number);
+}
+
+public sealed class OrderService : IOrderService
+{
+    public Task<string> SubmitAsync(string number)
+        => Task.FromResult($"submitted:{number}");
+}
+
+services.AddTransient<IOrderService, OrderService>();
+services.AddTransient<IInterceptor, AuditInterceptor>();
+services.AddInterceptedServices(); // v1.x used Castle at runtime
+```
+
+#### After: v2.0 generated interface proxy
+
+```csharp
+public interface IOrderService : IInterceptable
+{
+    Task<string> SubmitAsync(string number);
+}
+
+public sealed class OrderService : IOrderService
+{
+    public Task<string> SubmitAsync(string number)
+        => Task.FromResult($"submitted:{number}");
+}
+
+services.AddTransient<IOrderService, OrderService>();
+services.AddTransient<IInterceptor, AuditInterceptor>();
+services.AddInterceptedServices(); // v2.0 uses generated proxy metadata
+```
+
+No startup code change is required for supported interface-proxy shapes. The critical migration step is adding the DynamicProxy source generator analyzer to the consuming project and keeping the service shape supported.
+
+#### Supported preview.4 service shape
+
+- Service is registered through an interface, for example `IOrderService -> OrderService`.
+- The implementation type is `public` or `internal` in the consuming assembly.
+- The implementation implements `IInterceptable` through the service interface or another interface.
+- Intercepted methods are ordinary instance interface methods.
+- Supported return shapes: `void`, synchronous value, `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`.
+- Supported parameter passing: by-value parameters only.
+- Supported generic shape: closed generic service interfaces, such as `IEntityService<string>`.
+
+#### Known limitations in preview.4
+
+- No class-only proxy replacement. Register services through interfaces.
+- No `ref`, `out`, or `in` parameters. The generator reports `SKY3101`.
+- No generic methods such as `T Echo<T>(T value)` in preview.4. The generator reports `SKY3101`.
+- No open generic service registration proxy bridge unless a generated closed shape exists.
+- No factory/instance registration proxying when the implementation type cannot be known at compile time.
+- `IProxyGenerator` and `CastleProxyGenerator` calls must be removed; there is no runtime factory replacement in v2.0.
+
+#### Migration checklist
+
+1. Remove direct references to `Castle.Core`, `Castle.DynamicProxy`, `CastleProxyGenerator`, and `IProxyGenerator`.
+2. Add the DynamicProxy source generator analyzer to each project that declares intercepted services.
+3. Keep intercepted services registered as interface-to-implementation descriptors.
+4. Move class-only interception to an interface service contract.
+5. Replace `ref` / `out` / `in` parameters with by-value request/response models.
+6. Replace generic methods with non-generic methods on closed generic service interfaces, or keep them un-intercepted until a later preview supports generic methods.
+7. Run the source generator quality workflow or the AOT canary publish command to confirm no proxy-related `IL2xxx` / `IL3xxx` warnings.
+
+#### Diagnostics
+
+`SKY3101` documents unsupported method signatures: [SKY3101](../diagnostics/SKY3101.md).
 
 ---
 
@@ -212,7 +300,8 @@ dotnet publish samples/AotConsoleSample -c Release /p:PublishAot=true
 | 删除的 API / 包 | 在哪个 PR 删除 | 替换方案 |
 |---|---|---|
 | `AutoMapper` 依赖 | #181（main） | Mapperly |
-| *（待后续 PR 填充）* | — | — |
+| `Castle.Core` dependency from `Skywalker.Extensions.DynamicProxies` | #269 | DynamicProxy source generator analyzer + generated interface proxies |
+| `CastleProxyGenerator` / `IProxyGenerator` | #269 | Interface service registration covered by `Skywalker.Extensions.DynamicProxies.SourceGenerators` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Document the v1.x to v2.0 DynamicProxy migration path from Castle runtime proxies to source-generated static interface proxies.
- Add before/after examples, supported preview.4 service shapes, known limitations, and migration checklist entries.
- Expand SKY3101 diagnostic guidance with cause, incorrect/correct examples, and fix guidance.
- Add a preview.4 DynamicProxy readiness note and link it from the v2.0 roadmap.
- Update the changelog for the documentation work.

Refs #270