### PR TITLE
Generate DI registration metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- DI auto-registration Source Generator preview.5 首版 registration metadata 输出：属性标注服务会生成 `__SkywalkerDependencyInjectionRegistrar`，支持接口 fallback、显式 `ServiceType`、Scoped/Transient lifetime 映射，并对不可赋值服务类型报告 `SKY1002`（#280）。
 - DI auto-registration Source Generator preview.5 scaffolding：新增 analyzer-only `Skywalker.Ddd.Abstractions.SourceGenerators` 项目、首版 incremental generator skeleton、`SKY1xxx` diagnostics infrastructure 和最小 smoke tests；runtime package 暂不消费该 generator，后续 #280/#281 接入生成注册元数据与 `AddSkywalker()`（#279）。
 - DI auto-registration Source Generator preview.5 设计契约：定义 `[Service]` / `[ApplicationService]` / `[Repository]` / `[EventHandler]` attribute model、generated registrar shape、`AddSkywalker()` integration、convention fallback、`SKY1xxx` diagnostic candidates 和 readiness gates（#278）。
 - DynamicProxy Source Generator preview.4 迁移与诊断文档：补全 Castle → source-generated static proxy 的 before/after、支持/限制清单、`SKY3101` 修复指南和 preview.4 readiness 链接（#270）。

--- a/src/Skywalker.Ddd.Abstractions.SourceGenerators/DependencyInjectionRegistrationGenerator.cs
+++ b/src/Skywalker.Ddd.Abstractions.SourceGenerators/DependencyInjectionRegistrationGenerator.cs
@@ -26,6 +26,10 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
         "Skywalker.DependencyInjection.RepositoryAttribute",
         "Skywalker.DependencyInjection.EventHandlerAttribute");
 
+    private static readonly ImmutableArray<string> ExcludedInterfaceMetadataNames = ImmutableArray.Create(
+        "System.IDisposable",
+        "System.IAsyncDisposable");
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(static context =>
@@ -55,9 +59,18 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
 
         context.RegisterSourceOutput(registrations, static (context, models) =>
         {
+            foreach (var diagnostic in models.Select(static model => model.Diagnostic).Where(static diagnostic => diagnostic is not null))
+            {
+                context.ReportDiagnostic(diagnostic!);
+            }
+
             if (models.Length > 0)
             {
-                context.AddSource("Skywalker.Generated.DependencyInjectionRegistrar.g.cs", GenerateRegistrar(models));
+                var source = GenerateRegistrar(models);
+                if (!string.IsNullOrEmpty(source))
+                {
+                    context.AddSource("Skywalker.Generated.DependencyInjectionRegistrar.g.cs", source);
+                }
             }
         });
     }
@@ -65,7 +78,108 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
     private static ServiceRegistrationModel CreateModel(GeneratorAttributeSyntaxContext context)
     {
         var type = (INamedTypeSymbol)context.TargetSymbol;
-        return new ServiceRegistrationModel(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        var attribute = context.Attributes[0];
+        var implementationTypeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var serviceType = GetExplicitServiceType(attribute);
+        var lifetime = GetLifetime(attribute);
+
+        if (serviceType is not null)
+        {
+            if (!IsAssignableTo(type, serviceType))
+            {
+                var diagnostic = Diagnostic.Create(
+                    ServiceTypeMustBeAssignable,
+                    Location.None,
+                    serviceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    implementationTypeName);
+
+                return new ServiceRegistrationModel(
+                    implementationTypeName,
+                    lifetime,
+                    serviceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    diagnostic);
+            }
+
+            return new ServiceRegistrationModel(
+                implementationTypeName,
+                lifetime,
+                serviceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                null);
+        }
+
+        var serviceTypeNames = type.Interfaces
+            .Where(static candidate => !IsExcludedInterface(candidate))
+            .Select(static candidate => candidate.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+            .Distinct()
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (serviceTypeNames.Length == 0)
+        {
+            serviceTypeNames = new[] { implementationTypeName };
+        }
+
+        return new ServiceRegistrationModel(
+            implementationTypeName,
+            lifetime,
+            string.Join("|", serviceTypeNames),
+            null);
+    }
+
+    private static INamedTypeSymbol? GetExplicitServiceType(AttributeData attribute)
+    {
+        foreach (var argument in attribute.NamedArguments)
+        {
+            if (argument.Key == "ServiceType" && argument.Value.Value is INamedTypeSymbol serviceType)
+            {
+                return serviceType;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GetLifetime(AttributeData attribute)
+    {
+        var attributeName = attribute.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return attributeName == "global::Skywalker.DependencyInjection.EventHandlerAttribute"
+            ? "Transient"
+            : "Scoped";
+    }
+
+    private static bool IsAssignableTo(INamedTypeSymbol implementationType, INamedTypeSymbol serviceType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(implementationType, serviceType))
+        {
+            return true;
+        }
+
+        foreach (var candidate in implementationType.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(candidate, serviceType))
+            {
+                return true;
+            }
+        }
+
+        var baseType = implementationType.BaseType;
+        while (baseType is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(baseType, serviceType))
+            {
+                return true;
+            }
+
+            baseType = baseType.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool IsExcludedInterface(INamedTypeSymbol candidate)
+    {
+        var metadataName = candidate.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        return ExcludedInterfaceMetadataNames.Contains(metadataName, StringComparer.Ordinal);
     }
 
     private static string GenerateAttributes()
@@ -108,9 +222,27 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
 
     private static string GenerateRegistrar(ImmutableArray<ServiceRegistrationModel> models)
     {
+        var validModels = models
+            .Where(static model => model.Diagnostic is null)
+            .ToArray();
+
+        if (validModels.Length == 0)
+        {
+            return string.Empty;
+        }
+
         var registrations = string.Join(
             "\n",
-            models.Select(static model => $"        // TODO #280: emit descriptor for {model.ImplementationTypeName}"));
+            validModels.SelectMany(static model => model.ServiceTypeNames
+                .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(serviceTypeName => $$"""
+                        global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
+                            services,
+                            global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Describe(
+                                typeof({{serviceTypeName}}),
+                                typeof({{model.ImplementationTypeName}}),
+                                global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.{{model.Lifetime}}));
+                    """)));
 
         return $$"""
             // <auto-generated/>
@@ -132,5 +264,9 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
             """;
     }
 
-    private readonly record struct ServiceRegistrationModel(string ImplementationTypeName);
+    private readonly record struct ServiceRegistrationModel(
+        string ImplementationTypeName,
+        string Lifetime,
+        string ServiceTypeNames,
+        Diagnostic? Diagnostic);
 }

--- a/tests/Skywalker.SourceGenerators.Tests/DependencyInjectionRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/DependencyInjectionRegistrationGeneratorTests.cs
@@ -6,6 +6,18 @@ namespace Skywalker.SourceGenerators.Tests;
 
 public sealed class DependencyInjectionRegistrationGeneratorTests
 {
+    private static readonly MetadataReference[] DependencyInjectionReferences =
+    [
+        MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location),
+        CreateRuntimeReference("System.ComponentModel.dll"),
+    ];
+
+    private static MetadataReference CreateRuntimeReference(string assemblyFileName)
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        return MetadataReference.CreateFromFile(Path.Combine(runtimeDirectory, assemblyFileName));
+    }
+
     [Fact]
     public void ProducesOnlyAttributeSource_ForNoCandidateServices()
     {
@@ -36,7 +48,7 @@ public sealed class DependencyInjectionRegistrationGeneratorTests
             }
             """,
             new DependencyInjectionRegistrationGenerator(),
-            [MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location)]);
+            DependencyInjectionReferences);
 
         Assert.Equal(2, result.GeneratedTrees.Length);
 
@@ -45,8 +57,167 @@ public sealed class DependencyInjectionRegistrationGeneratorTests
 
         Assert.Contains("__SkywalkerDependencyInjectionRegistrar", registrarSource);
         Assert.Contains("Register(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)", registrarSource);
-        Assert.Contains("TODO #280: emit descriptor for global::Demo.OrderService", registrarSource);
+        Assert.Contains("typeof(global::Demo.OrderService)", registrarSource);
+        Assert.Contains("ServiceLifetime.Scoped", registrarSource);
+        Assert.Contains("ServiceCollectionDescriptorExtensions.TryAdd", registrarSource);
         Assert.Empty(result.Diagnostics);
         Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void GeneratesScopedRegistration_ForDiscoveredInterface()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using Skywalker.DependencyInjection;
+
+            namespace Demo;
+
+            public interface IOrderService
+            {
+            }
+
+            [ApplicationService]
+            public sealed class OrderService : IOrderService
+            {
+            }
+            """,
+            new DependencyInjectionRegistrationGenerator(),
+            DependencyInjectionReferences);
+
+        var registrarSource = Assert.Single(result.GeneratedTrees, static tree => tree.FilePath.EndsWith("Skywalker.Generated.DependencyInjectionRegistrar.g.cs"))
+            .GetText()
+            .ToString();
+
+        Assert.Contains("typeof(global::Demo.IOrderService)", registrarSource);
+        Assert.Contains("typeof(global::Demo.OrderService)", registrarSource);
+        Assert.Contains("ServiceLifetime.Scoped", registrarSource);
+        Assert.Empty(result.Diagnostics);
+        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void GeneratesTransientRegistration_ForEventHandler()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using Skywalker.DependencyInjection;
+
+            namespace Demo;
+
+            public interface IOrderPlacedHandler
+            {
+            }
+
+            [EventHandler]
+            public sealed class OrderPlacedHandler : IOrderPlacedHandler
+            {
+            }
+            """,
+            new DependencyInjectionRegistrationGenerator(),
+            DependencyInjectionReferences);
+
+        var registrarSource = Assert.Single(result.GeneratedTrees, static tree => tree.FilePath.EndsWith("Skywalker.Generated.DependencyInjectionRegistrar.g.cs"))
+            .GetText()
+            .ToString();
+
+        Assert.Contains("typeof(global::Demo.IOrderPlacedHandler)", registrarSource);
+        Assert.Contains("ServiceLifetime.Transient", registrarSource);
+        Assert.Empty(result.Diagnostics);
+        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void GeneratesExplicitServiceTypeRegistration()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using Skywalker.DependencyInjection;
+
+            namespace Demo;
+
+            public interface IOrderService
+            {
+            }
+
+            [Service(ServiceType = typeof(IOrderService))]
+            public sealed class OrderService : IOrderService
+            {
+            }
+            """,
+            new DependencyInjectionRegistrationGenerator(),
+            DependencyInjectionReferences);
+
+        var registrarSource = Assert.Single(result.GeneratedTrees, static tree => tree.FilePath.EndsWith("Skywalker.Generated.DependencyInjectionRegistrar.g.cs"))
+            .GetText()
+            .ToString();
+
+        Assert.Contains("typeof(global::Demo.IOrderService)", registrarSource);
+        Assert.Empty(result.Diagnostics);
+        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void ReportsDiagnostic_ForUnassignableExplicitServiceType()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using Skywalker.DependencyInjection;
+
+            namespace Demo;
+
+            public interface IOrderService
+            {
+            }
+
+            [Service(ServiceType = typeof(IOrderService))]
+            public sealed class PlainService
+            {
+            }
+            """,
+            new DependencyInjectionRegistrationGenerator(),
+            DependencyInjectionReferences);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("SKY1002", diagnostic.Id);
+        Assert.DoesNotContain(result.GeneratedTrees, static tree => tree.FilePath.EndsWith("Skywalker.Generated.DependencyInjectionRegistrar.g.cs"));
+        Assert.Empty(compilation.GetDiagnostics().Where(static item => item.Severity == DiagnosticSeverity.Error && item.Id != "CS8019"));
+    }
+
+    [Fact]
+    public void GeneratesValidRegistrations_WhenAnotherServiceReportsDiagnostic()
+    {
+        var (result, compilation) = GeneratorTestHelper.RunWithCompilation("""
+            using Skywalker.DependencyInjection;
+
+            namespace Demo;
+
+            public interface IOrderService
+            {
+            }
+
+            public interface ICustomerService
+            {
+            }
+
+            [Service(ServiceType = typeof(IOrderService))]
+            public sealed class OrderService : IOrderService
+            {
+            }
+
+            [Service(ServiceType = typeof(ICustomerService))]
+            public sealed class PlainService
+            {
+            }
+            """,
+            new DependencyInjectionRegistrationGenerator(),
+            DependencyInjectionReferences);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("SKY1002", diagnostic.Id);
+
+        var registrarSource = Assert.Single(result.GeneratedTrees, static tree => tree.FilePath.EndsWith("Skywalker.Generated.DependencyInjectionRegistrar.g.cs"))
+            .GetText()
+            .ToString();
+
+        Assert.Contains("typeof(global::Demo.IOrderService)", registrarSource);
+        Assert.DoesNotContain("typeof(global::Demo.ICustomerService)", registrarSource);
+        Assert.Empty(compilation.GetDiagnostics().Where(static item => item.Severity == DiagnosticSeverity.Error && item.Id != "CS8019"));
     }
 }


### PR DESCRIPTION
## Summary
- generate the DI registrar body for attributed services
- support direct-interface and self-registration fallback metadata
- support explicit ServiceType metadata with SKY1002 validation
- map EventHandler services to Transient and other DI attributes to Scoped
- keep valid registrations emitted when another candidate reports a diagnostic

## Tests
- dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj --configuration Release --filter FullyQualifiedName~DependencyInjectionRegistrationGeneratorTests -p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false --nologo --logger console;verbosity=minimal
- dotnet build src/Skywalker.Ddd.Abstractions.SourceGenerators/Skywalker.Ddd.Abstractions.SourceGenerators.csproj --configuration Release -p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false --nologo
- dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj --configuration Release --no-build --logger console;verbosity=minimal

Refs #280