### PR TITLE
Integrate generated DI registrar with AddSkywalker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - DI auto-registration Source Generator preview.5 首版 registration metadata 输出：属性标注服务会生成 `__SkywalkerDependencyInjectionRegistrar`，支持接口 fallback、显式 `ServiceType`、Scoped/Transient lifetime 映射，并对不可赋值服务类型报告 `SKY1002`（#280）。
+- DI auto-registration Source Generator preview.5 runtime bridge：`AddSkywalker()` 现在可通过 assembly metadata 消费生成的 DI registrar，并保留现有 FeatureProvider fallback 路径（#281）。
 - DI auto-registration Source Generator preview.5 scaffolding：新增 analyzer-only `Skywalker.Ddd.Abstractions.SourceGenerators` 项目、首版 incremental generator skeleton、`SKY1xxx` diagnostics infrastructure 和最小 smoke tests；runtime package 暂不消费该 generator，后续 #280/#281 接入生成注册元数据与 `AddSkywalker()`（#279）。
 - DI auto-registration Source Generator preview.5 设计契约：定义 `[Service]` / `[ApplicationService]` / `[Repository]` / `[EventHandler]` attribute model、generated registrar shape、`AddSkywalker()` integration、convention fallback、`SKY1xxx` diagnostic candidates 和 readiness gates（#278）。
 - DynamicProxy Source Generator preview.4 迁移与诊断文档：补全 Castle → source-generated static proxy 的 before/after、支持/限制清单、`SKY3101` 修复指南和 preview.4 readiness 链接（#270）。

--- a/docs/architecture/di-auto-registration-sg-contract.md
+++ b/docs/architecture/di-auto-registration-sg-contract.md
@@ -1,7 +1,7 @@
 # DI Auto-Registration Source Generator Contract
 
 > Status: Draft for v2.0.0-preview.5  
-> Tracking: #254, #278  
+> Tracking: #254, #278, #281
 > Last updated: 2026-05-03
 
 This contract defines the supported shape for the DI auto-registration source generator. The goal is to move `AddSkywalker()` from runtime feature-provider scanning toward compile-time generated service registration metadata while preserving the existing service registration semantics.
@@ -108,23 +108,24 @@ Each consumer assembly that contains supported services gets one generated regis
 #nullable enable
 #pragma warning disable
 
+[assembly: global::Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute(
+  typeof(global::Skywalker.Generated.__SkywalkerDependencyInjectionRegistrar),
+  nameof(global::Skywalker.Generated.__SkywalkerDependencyInjectionRegistrar.AddSkywalkerGeneratedServices))]
+
 namespace Skywalker.Generated;
 
 internal static class __SkywalkerDependencyInjectionRegistrar
 {
-    internal static void Register(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+  public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddSkywalkerGeneratedServices(
+    Microsoft.Extensions.DependencyInjection.IServiceCollection services)
     {
         // generated TryAdd / Replace calls
+    return services;
     }
 }
 ```
 
-The implementation can choose one of two runtime bridge shapes:
-
-1. Assembly metadata attribute that points to the generated registrar method.
-2. Module initializer that registers the assembly and delegate with a runtime registry.
-
-Preview.5 should prefer the module-initializer registry only if it avoids extra reflection and works for library assemblies. Otherwise, an assembly metadata attribute is acceptable as an intermediate bridge because EF Repository SG and DynamicProxy SG already use generated metadata attributes successfully.
+Preview.5 uses an assembly metadata attribute, `SkywalkerGeneratedDependencyInjectionRegistrationAttribute`, that points `AddSkywalker()` to the generated registrar method. The method must be static, accept `IServiceCollection`, and return `IServiceCollection`. Invalid generated metadata fails with an actionable `InvalidOperationException` instead of being ignored.
 
 ## AddSkywalker Integration
 
@@ -132,7 +133,7 @@ Preview.5 should prefer the module-initializer registry only if it avoids extra 
 
 1. Discover generated registrars for the entry assembly and related Skywalker assemblies.
 2. Invoke generated registration for assemblies that provide metadata.
-3. Run the runtime feature-provider path only for assemblies without generated metadata, unless the generated path is configured as strict.
+3. Run the runtime feature-provider path as the compatibility fallback, including when no generated DI metadata exists.
 4. Apply `AddInterceptedServices()` after service descriptors are finalized, matching current behavior.
 
 Generated registrations must keep existing ordering rules:

--- a/src/Skywalker.Ddd.Abstractions.SourceGenerators/DependencyInjectionRegistrationGenerator.cs
+++ b/src/Skywalker.Ddd.Abstractions.SourceGenerators/DependencyInjectionRegistrationGenerator.cs
@@ -252,13 +252,16 @@ public sealed class DependencyInjectionRegistrationGenerator : IIncrementalGener
             #nullable enable
             #pragma warning disable
 
+            [assembly: global::Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute(typeof(global::Skywalker.Generated.__SkywalkerDependencyInjectionRegistrar), nameof(global::Skywalker.Generated.__SkywalkerDependencyInjectionRegistrar.AddSkywalkerGeneratedServices))]
+
             namespace Skywalker.Generated;
 
             internal static class __SkywalkerDependencyInjectionRegistrar
             {
-                internal static void Register(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+                public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSkywalkerGeneratedServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
                 {
             {{registrations}}
+                    return services;
                 }
             }
             """;

--- a/src/Skywalker.Ddd.Abstractions/Microsoft/Extensions/DependencyInjection/SkywalkerServiceCollectionExtensions.cs
+++ b/src/Skywalker.Ddd.Abstractions/Microsoft/Extensions/DependencyInjection/SkywalkerServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Skywalker;
 using Skywalker.ApplicationParts;
+using Skywalker.DependencyInjection;
 using Skywalker.Extensions.DynamicProxies;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -65,6 +66,8 @@ public static class SkywalkerServiceCollectionExtensions
             }
         }
 
+        AddGeneratedDependencyInjectionRegistrars(services, partManager);
+
         // 通过 PartManager 统一收集所有服务描述符
         var feature = new ServiceRegistrationFeature { ServiceCollection = services };
         partManager.PopulateFeature(feature);
@@ -85,5 +88,28 @@ public static class SkywalkerServiceCollectionExtensions
         services.AddInterceptedServices();
 
         return new SkywalkerBuilder(services, partManager);
+    }
+
+    private static void AddGeneratedDependencyInjectionRegistrars(IServiceCollection services, SkywalkerPartManager partManager)
+    {
+        foreach (var part in partManager.ApplicationParts.OfType<AssemblyPart>())
+        {
+            foreach (var attribute in part.Assembly.GetCustomAttributes<SkywalkerGeneratedDependencyInjectionRegistrationAttribute>())
+            {
+                var method = attribute.RegistrarType.GetMethod(
+                    attribute.MethodName,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                    binder: null,
+                    types: [typeof(IServiceCollection)],
+                    modifiers: null);
+
+                if (method is null || !typeof(IServiceCollection).IsAssignableFrom(method.ReturnType))
+                {
+                    throw new InvalidOperationException($"DI source generator emitted invalid registration metadata for '{part.Assembly.FullName}'. Registrar '{attribute.RegistrarType.FullName}.{attribute.MethodName}' must be a static method that accepts IServiceCollection and returns IServiceCollection.");
+                }
+
+                method.Invoke(null, [services]);
+            }
+        }
     }
 }

--- a/src/Skywalker.Ddd.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Skywalker.Ddd.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute
+Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute.MethodName.get -> string!
+Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute.RegistrarType.get -> System.Type!
+Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute.SkywalkerGeneratedDependencyInjectionRegistrationAttribute(System.Type! registrarType, string! methodName) -> void

--- a/src/Skywalker.Ddd.Abstractions/Skywalker/DependencyInjection/SkywalkerGeneratedDependencyInjectionRegistrationAttribute.cs
+++ b/src/Skywalker.Ddd.Abstractions/Skywalker/DependencyInjection/SkywalkerGeneratedDependencyInjectionRegistrationAttribute.cs
@@ -1,0 +1,15 @@
+namespace Skywalker.DependencyInjection;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class SkywalkerGeneratedDependencyInjectionRegistrationAttribute : Attribute
+{
+    public SkywalkerGeneratedDependencyInjectionRegistrationAttribute(Type registrarType, string methodName)
+    {
+        RegistrarType = registrarType;
+        MethodName = methodName;
+    }
+
+    public Type RegistrarType { get; }
+
+    public string MethodName { get; }
+}

--- a/tests/Skywalker.Ddd.Tests/GeneratedDependencyInjectionRegistrationBridgeTests.cs
+++ b/tests/Skywalker.Ddd.Tests/GeneratedDependencyInjectionRegistrationBridgeTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Skywalker;
+using Skywalker.DependencyInjection;
+
+[assembly: SkywalkerGeneratedDependencyInjectionRegistrationAttribute(
+    typeof(Skywalker.Ddd.Tests.GeneratedDependencyInjectionRegistrar),
+    nameof(Skywalker.Ddd.Tests.GeneratedDependencyInjectionRegistrar.AddGeneratedServices))]
+
+namespace Skywalker.Ddd.Tests;
+
+public sealed class GeneratedDependencyInjectionRegistrationBridgeTests
+{
+    [Fact]
+    public void AddSkywalker_UsesGeneratedDependencyInjectionRegistration_WhenAssemblyMetadataExists()
+    {
+        var services = CreateServices();
+
+        services.AddSkywalker(typeof(GeneratedDependencyInjectionRegistrationBridgeTests).Assembly);
+
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(IGeneratedDependencyInjectionService) &&
+            descriptor.ImplementationType == typeof(GeneratedDependencyInjectionService) &&
+            descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddSkywalker_DoesNotOverwriteExistingRegistration_WhenGeneratedRegistrarUsesTryAdd()
+    {
+        var services = CreateServices();
+        var service = new ManualGeneratedDependencyInjectionService();
+        services.AddSingleton<IGeneratedDependencyInjectionService>(service);
+
+        services.AddSkywalker(typeof(GeneratedDependencyInjectionRegistrationBridgeTests).Assembly);
+
+        var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IGeneratedDependencyInjectionService));
+        Assert.Same(service, descriptor.ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddSkywalker_KeepsFeatureProviderFallback_WhenGeneratedDependencyInjectionMetadataIsMissing()
+    {
+        var services = CreateServices();
+
+        services.AddSkywalker(typeof(SkywalkerServiceCollectionExtensions).Assembly);
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(SkywalkerPartManager));
+    }
+
+    private static IServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return services;
+    }
+}
+
+public interface IGeneratedDependencyInjectionService
+{
+}
+
+public sealed class GeneratedDependencyInjectionService : IGeneratedDependencyInjectionService
+{
+}
+
+public sealed class ManualGeneratedDependencyInjectionService : IGeneratedDependencyInjectionService
+{
+}
+
+internal static class GeneratedDependencyInjectionRegistrar
+{
+    public static IServiceCollection AddGeneratedServices(IServiceCollection services)
+    {
+        services.TryAddScoped<IGeneratedDependencyInjectionService, GeneratedDependencyInjectionService>();
+        return services;
+    }
+}

--- a/tests/Skywalker.SourceGenerators.Tests/DependencyInjectionRegistrationGeneratorTests.cs
+++ b/tests/Skywalker.SourceGenerators.Tests/DependencyInjectionRegistrationGeneratorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Skywalker.Ddd.Abstractions.SourceGenerators;
+using Skywalker.DependencyInjection;
 
 namespace Skywalker.SourceGenerators.Tests;
 
@@ -9,6 +10,7 @@ public sealed class DependencyInjectionRegistrationGeneratorTests
     private static readonly MetadataReference[] DependencyInjectionReferences =
     [
         MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(SkywalkerGeneratedDependencyInjectionRegistrationAttribute).Assembly.Location),
         CreateRuntimeReference("System.ComponentModel.dll"),
     ];
 
@@ -56,7 +58,9 @@ public sealed class DependencyInjectionRegistrationGeneratorTests
         var registrarSource = registrarTree.GetText().ToString();
 
         Assert.Contains("__SkywalkerDependencyInjectionRegistrar", registrarSource);
-        Assert.Contains("Register(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)", registrarSource);
+        Assert.Contains("[assembly: global::Skywalker.DependencyInjection.SkywalkerGeneratedDependencyInjectionRegistrationAttribute", registrarSource);
+        Assert.Contains("AddSkywalkerGeneratedServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)", registrarSource);
+        Assert.Contains("return services;", registrarSource);
         Assert.Contains("typeof(global::Demo.OrderService)", registrarSource);
         Assert.Contains("ServiceLifetime.Scoped", registrarSource);
         Assert.Contains("ServiceCollectionDescriptorExtensions.TryAdd", registrarSource);


### PR DESCRIPTION
## Summary
- add SkywalkerGeneratedDependencyInjectionRegistrationAttribute for generated DI registrar metadata
- make AddSkywalker() discover and invoke generated DI registrars before the existing FeatureProvider fallback
- update the DI generator to emit assembly metadata and an IServiceCollection-returning registrar method
- add runtime bridge tests for generated metadata, manual registration preservation, and missing-metadata fallback
- update the DI SG contract and changelog

## Tests
- dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj --configuration Release --filter FullyQualifiedName~DependencyInjectionRegistrationGeneratorTests -p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false --nologo --logger console;verbosity=minimal
- dotnet test tests/Skywalker.Ddd.Tests/Skywalker.Ddd.Tests.csproj --configuration Release --filter FullyQualifiedName~GeneratedDependencyInjectionRegistrationBridgeTests -p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false --nologo --logger console;verbosity=minimal
- dotnet test tests/Skywalker.SourceGenerators.Tests/Skywalker.SourceGenerators.Tests.csproj --configuration Release --no-build --logger console;verbosity=minimal
- dotnet test tests/Skywalker.Ddd.Tests/Skywalker.Ddd.Tests.csproj --configuration Release --no-build --logger console;verbosity=minimal
- dotnet build src/Skywalker.Ddd.Abstractions/Skywalker.Ddd.Abstractions.csproj --configuration Release -p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false --nologo
- git diff --check

Refs #281