### PR TITLE
Document DI source generator diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - DI auto-registration Source Generator preview.5 首版 registration metadata 输出：属性标注服务会生成 `__SkywalkerDependencyInjectionRegistrar`，支持接口 fallback、显式 `ServiceType`、Scoped/Transient lifetime 映射，并对不可赋值服务类型报告 `SKY1002`（#280）。
 - DI auto-registration Source Generator preview.5 runtime bridge：`AddSkywalker()` 现在可通过 assembly metadata 消费生成的 DI registrar，并保留现有 FeatureProvider fallback 路径（#281）。
 - DI auto-registration Source Generator preview.5 测试安全网：新增主要 registrar 生成形状的 snapshot 覆盖，以及 generated registration 的解析、Scoped lifetime、idempotency runtime 测试（#282）。
+- DI auto-registration Source Generator preview.5 诊断文档：新增 `SKY1002` 修复指南，并从诊断索引和 DI SG contract 链接（#283）。
 - DI auto-registration Source Generator preview.5 scaffolding：新增 analyzer-only `Skywalker.Ddd.Abstractions.SourceGenerators` 项目、首版 incremental generator skeleton、`SKY1xxx` diagnostics infrastructure 和最小 smoke tests；runtime package 暂不消费该 generator，后续 #280/#281 接入生成注册元数据与 `AddSkywalker()`（#279）。
 - DI auto-registration Source Generator preview.5 设计契约：定义 `[Service]` / `[ApplicationService]` / `[Repository]` / `[EventHandler]` attribute model、generated registrar shape、`AddSkywalker()` integration、convention fallback、`SKY1xxx` diagnostic candidates 和 readiness gates（#278）。
 - DynamicProxy Source Generator preview.4 迁移与诊断文档：补全 Castle → source-generated static proxy 的 before/after、支持/限制清单、`SKY3101` 修复指南和 preview.4 readiness 链接（#270）。

--- a/docs/architecture/di-auto-registration-sg-contract.md
+++ b/docs/architecture/di-auto-registration-sg-contract.md
@@ -168,7 +168,7 @@ Initial diagnostic candidates:
 | ID | Condition | Severity |
 |---|---|---|
 | `SKY1001` | Implementation type is not accessible from generated code. | Warning |
-| `SKY1002` | Service type cannot be assigned from implementation type. | Error |
+| [`SKY1002`](../diagnostics/SKY1002.md) | Service type cannot be assigned from implementation type. | Error |
 | `SKY1003` | Open generic registration is not supported in preview.5. | Warning |
 | `SKY1004` | Keyed service key cannot be emitted as generated code. | Warning |
 | `SKY1005` | Multiple attributes define conflicting lifetimes or service types. | Warning |

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -29,6 +29,12 @@ the diagnostic ID as the file name: `docs/diagnostics/SKYxxxx.md`.
 | `SKY3005` | Entity type is exposed by multiple DbSet properties |
 | `SKY3006` | Entity key type inference is ambiguous |
 
+## DI And Service Registration
+
+| ID | Title |
+|---|---|
+| `SKY1002` | Service type must be assignable from implementation type |
+
 ## DynamicProxy Source Generation
 
 | ID | Title |

--- a/docs/diagnostics/SKY1002.md
+++ b/docs/diagnostics/SKY1002.md
@@ -1,0 +1,69 @@
+# SKY1002: Service type must be assignable from implementation type
+
+| Item | Value |
+|---|---|
+| Severity | Error |
+| Introduced in | 2.0.0-preview.5 |
+| Category | Skywalker.Ddd.Abstractions.SourceGenerators |
+
+## Cause
+
+The DI auto-registration source generator found a service registration attribute with an explicit `ServiceType`, but the implementation type cannot be assigned to that service type.
+
+The generated registrar must create a valid `ServiceDescriptor` where the service type can resolve to the implementation type. If the implementation does not implement or inherit from the requested service type, dependency injection would fail at runtime, so the generator reports this as a compile-time error.
+
+## Incorrect Example
+
+```csharp
+using Skywalker.DependencyInjection;
+
+public interface IOrderService
+{
+}
+
+[Service(ServiceType = typeof(IOrderService))]
+public sealed class CustomerService
+{
+}
+```
+
+`CustomerService` does not implement `IOrderService`, so the generated registration would be invalid.
+
+## Correct Example
+
+```csharp
+using Skywalker.DependencyInjection;
+
+public interface IOrderService
+{
+}
+
+[Service(ServiceType = typeof(IOrderService))]
+public sealed class OrderService : IOrderService
+{
+}
+```
+
+If the implementation should be registered as itself, omit `ServiceType`:
+
+```csharp
+using Skywalker.DependencyInjection;
+
+[Service]
+public sealed class ClockService
+{
+}
+```
+
+## Fix Guidance
+
+1. Make the implementation class implement or inherit from the type passed to `ServiceType`.
+2. Change `ServiceType` to the interface or base type that the implementation actually supports.
+3. Remove `ServiceType` when self-registration is intended.
+4. For multiple exposed service types, use the established `ExposeServicesAttribute` contract and ensure every exposed type is assignable from the implementation.
+
+## Related Links
+
+- [DI auto-registration source generator contract](../architecture/di-auto-registration-sg-contract.md)
+- [Source Generator design specification](../architecture/source-generators-spec.md)
+- [v2.0 roadmap](../architecture/v2.0-roadmap.md)


### PR DESCRIPTION
## Summary
- add the SKY1002 diagnostic page with cause, incorrect/correct examples, and fix guidance
- link SKY1002 from the diagnostics index and DI auto-registration SG contract
- record the preview.5 diagnostic docs update in the changelog

## Tests
- git diff --check

Refs #283