### PR TITLE
feat: bundle SG analyzers into runtime packages (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Added
 
+- 运行时包捆绑 source generator analyzer（#298）：`Skywalker.Ddd.EntityFrameworkCore`、`Skywalker.Ddd.Abstractions`、`Skywalker.Extensions.DynamicProxies` 现在把各自的 SG analyzer DLL 打进包内 `analyzers/dotnet/cs`——只装运行时包的 NuGet 用户默认即获得零反射 generated registration / static proxies，不再静默落到反射 fallback（NativeAOT 下不再抛错）。独立的 `*.SourceGenerators` opt-in 包继续发布，显式引用者不受影响。
 - 架构依赖方向护栏：`eng/Check-ArchitectureDependencies.ps1` + `.github/workflows/arch-guard.yml`，CI 强制“除 `Skywalker.Ddd` 外一切不得反向依赖 `Skywalker.Ddd`、内核不得拉入增强家族、`Extensions.*` 保持最底层、内核依赖 EventBus 端口而非实现”等不变量，防止架构回归；`*.EntityFrameworkCore` 识别为合法 DDD 持久化适配器（#297，Epic #300）。
 - DI auto-registration Source Generator preview.5 首版 registration metadata 输出：属性标注服务会生成 `__SkywalkerDependencyInjectionRegistrar`，支持接口 fallback、显式 `ServiceType`、Scoped/Transient lifetime 映射，并对不可赋值服务类型报告 `SKY1002`（#280）。
 - DI auto-registration Source Generator preview.5 runtime bridge：`AddSkywalker()` 现在可通过 assembly metadata 消费生成的 DI registrar，并保留现有 FeatureProvider fallback 路径（#281）。

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -31,7 +31,7 @@
 
 1. **试 preview 包**：`2.0.0-preview.N`（来自 `release/2.0` 分支自动发布）
 2. **对照本文档**逐模块迁移
-3. 给声明 source-generator 覆盖类型的项目添加对应 analyzer 包引用；使用 Skywalker NuGet 包时 analyzer 随 generator 包进入 `analyzers/dotnet/cs`。
+3. 使用 Skywalker NuGet 包时无需额外引用 analyzer：runtime 包（`Skywalker.Ddd.EntityFrameworkCore` / `Skywalker.Ddd.Abstractions` / `Skywalker.Extensions.DynamicProxies`）已把对应 SG analyzer 捆绑进 `analyzers/dotnet/cs`（#298）。仓库内项目引用（非 NuGet）仍需按下文示例显式加 analyzer ProjectReference。
 4. 跑测试，确认无 source-generator 诊断和 AOT/trim 警告（参考 [`7. NativeAOT 零警告验证`](#7-nativeaot--零警告验证)）。
 5. 发现遗漏请提 issue 并打标签 `migration`
 
@@ -140,12 +140,11 @@ builder.Services.AddSkywalkerDbContext<AppDbContext>(options =>
 
 #### 必需项目引用
 
-消费项目需要同时引用 runtime 包和 source generator analyzer。项目引用写法如下；NuGet 使用时 generator 包也应作为 analyzer/private asset 引入。
+NuGet 使用时只需引用 runtime 包——SG analyzer 已捆绑在包内 `analyzers/dotnet/cs`，自动生效（#298）：
 
 ```xml
 <ItemGroup>
   <PackageReference Include="Skywalker.Extensions.DynamicProxies" Version="2.0.0-preview.*" />
-  <PackageReference Include="Skywalker.Extensions.DynamicProxies.SourceGenerators" Version="2.0.0-preview.*" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 </ItemGroup>
 ```
 

--- a/docs/release-notes/v2.0.0-rc.1.md
+++ b/docs/release-notes/v2.0.0-rc.1.md
@@ -26,7 +26,7 @@ Skywalker v2.0.0-rc.1 is the release-candidate cut for the source-generator rewr
 ## Migration Notes
 
 - Use `AddSkywalker()` as the unified framework entry point, then configure module-specific services such as EF Core through their existing extension methods.
-- Add source generator analyzer packages to projects that declare generated service/proxy/repository shapes.
+- Source generator analyzers ship inside the runtime packages (`Skywalker.Ddd.EntityFrameworkCore`, `Skywalker.Ddd.Abstractions`, `Skywalker.Extensions.DynamicProxies`); installing the runtime package is enough to get zero-reflection generated registration. The standalone `*.SourceGenerators` packages remain published for analyzer-only or repo-internal scenarios (#298).
 - Fix source-generator diagnostics instead of relying on runtime fallback. Diagnostic docs live under `docs/diagnostics/`.
 - See `docs/migration/v1-to-v2.md` for the supported migration path and current limitations.
 

--- a/src/Skywalker.Ddd.Abstractions/Skywalker.Ddd.Abstractions.csproj
+++ b/src/Skywalker.Ddd.Abstractions/Skywalker.Ddd.Abstractions.csproj
@@ -14,4 +14,10 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Skywalker.Extensions.DynamicProxies\Skywalker.Extensions.DynamicProxies.csproj" />
   </ItemGroup>
 
+  <!-- 捆绑 DI auto-registration source generator：装运行时包即获得零反射 generated registration（#298） -->
+  <ItemGroup>
+    <ProjectReference Include="$(LibrariesProjectRoot)Skywalker.Ddd.Abstractions.SourceGenerators\Skywalker.Ddd.Abstractions.SourceGenerators.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(LibrariesProjectRoot)Skywalker.Ddd.Abstractions.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Ddd.Abstractions.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/Skywalker.Ddd.EntityFrameworkCore/Skywalker.Ddd.EntityFrameworkCore.csproj
+++ b/src/Skywalker.Ddd.EntityFrameworkCore/Skywalker.Ddd.EntityFrameworkCore.csproj
@@ -17,4 +17,10 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Skywalker.Extensions.Timezone\Skywalker.Extensions.Timezone.csproj" />
   </ItemGroup>
 
+  <!-- 捆绑 EF 仓储注册 source generator：装运行时包即获得零反射 generated registration（#298） -->
+  <ItemGroup>
+    <ProjectReference Include="$(LibrariesProjectRoot)Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(LibrariesProjectRoot)Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/Skywalker.Extensions.DynamicProxies/Skywalker.Extensions.DynamicProxies.csproj
+++ b/src/Skywalker.Extensions.DynamicProxies/Skywalker.Extensions.DynamicProxies.csproj
@@ -9,4 +9,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 
+  <!-- 捆绑 DynamicProxy source generator：装运行时包即获得 source-generated static proxies（#298） -->
+  <ItemGroup>
+    <ProjectReference Include="$(LibrariesProjectRoot)Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(LibrariesProjectRoot)Skywalker.Extensions.DynamicProxies.SourceGenerators\bin\$(Configuration)\netstandard2.0\Skywalker.Extensions.DynamicProxies.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Fixes #298 — option **(a)** from the issue: the three runtime packages now bundle their source-generator analyzer into `analyzers/dotnet/cs`, so a NuGet consumer that installs only the runtime framework gets zero-reflection generated registration by default. The "install the framework, get zero reflection" promise of v2.0 now holds without any extra analyzer package reference.

| Runtime package | Bundled analyzer |
|---|---|
| `Skywalker.Ddd.EntityFrameworkCore` | `Skywalker.Ddd.EntityFrameworkCore.SourceGenerators` |
| `Skywalker.Ddd.Abstractions` | `Skywalker.Ddd.Abstractions.SourceGenerators` |
| `Skywalker.Extensions.DynamicProxies` | `Skywalker.Extensions.DynamicProxies.SourceGenerators` |

## Design notes

- `ProjectReference` with `ReferenceOutputAssembly="false" PrivateAssets="all"` gives build ordering without flowing a nuspec dependency — verified the packed nuspecs carry **no** `*.SourceGenerators` dependency.
- Analyzers flow transitively through NuGet, so e.g. installing `Skywalker.Ddd.EntityFrameworkCore` also activates the DI SG bundled in `Skywalker.Ddd.Abstractions` down the dependency chain.
- Standalone `*.SourceGenerators` opt-in packages keep publishing (unchanged). Roslyn loads one analyzer instance per assembly identity, so installing both runtime + standalone analyzer package is harmless.
- Architecture guard: new edges are same-family (ddd→ddd, extensions→extensions) — no INV rule triggered, verified locally.

## Verification

- **End-to-end consumer proof**: packed the full solution to a local feed, created a clean net8.0 console app referencing **only** `Skywalker.Ddd.EntityFrameworkCore` + EF InMemory, hard-disabled the reflection fallback via `AppContext.SetSwitch("Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback", true)`, and confirmed `AddSkywalkerDbContext` registers `IRepository<,>` via `TryAddGeneratedDefaultServices` → **PASS** (previously this threw).
- Package inspection: all three nupkgs contain `analyzers/dotnet/cs/<SG>.dll`; nuspecs have no SG dependency.
- Full solution build: 0 warnings / 0 errors. Arch guard: OK. Tests: SourceGenerators 110/110, EF Core 24/24, DynamicProxies 14/14.

## Docs

- CHANGELOG `[Unreleased]` entry.
- rc.1 release notes migration note updated: no analyzer package needed for NuGet users.
- `docs/migration/v1-to-v2.md`: upgrade step 3 and the DynamicProxies package-reference example simplified accordingly (in-repo ProjectReference guidance unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
