### PR TITLE
chore: drop unreferenced version variables from Versions.props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ### Changed
 
+- 清理 `eng/Versions.props` 中无引用的版本变量：Messaging/Transport spin-out 遗留的 NetMQ/Grpc.\*/Google.Protobuf/MessagePack 以及反射扫描时代遗留的 Scrutor，全仓无任何项目引用。
 - Source Generator sample projects 统一关闭 package SourceLink/SCM metadata，避免 sample app 构建触发打包专用 SourceLink target；`AspireAOT` analyzer project references 同步简化，防止 solution build 中生成器项目重复实例造成文件锁。
 - `Scriban` 升级到 `7.2.3`，解除 `NU1903` 高危漏洞 advisory 对 warnings-as-errors build 的阻塞。
 - 迁移到 [MinVer](https://github.com/adamralph/minver) 由 git tag 驱动版本号 (#213, #215)。

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,17 +41,10 @@
 
   <PropertyGroup Label="Third-Party">
     <FluentValidationVersion>11.9.0</FluentValidationVersion>
-    <GoogleProtobufVersion>3.28.3</GoogleProtobufVersion>
-    <GrpcNetClientVersion>2.66.0</GrpcNetClientVersion>
-    <GrpcAspNetCoreVersion>2.66.0</GrpcAspNetCoreVersion>
-    <GrpcToolsVersion>2.66.0</GrpcToolsVersion>
-    <MessagePackVersion>3.1.3</MessagePackVersion>
-    <NetMQVersion>4.0.1.13</NetMQVersion>
     <PomeloEntityFrameworkCoreMySqlVersion>9.0.0</PomeloEntityFrameworkCoreMySqlVersion>
     <RabbitMQClientVersion>6.8.1</RabbitMQClientVersion>
     <RazorLightVersion>2.3.1</RazorLightVersion>
     <ScribanVersion>7.2.3</ScribanVersion>
-    <ScrutorVersion>5.0.1</ScrutorVersion>
     <StackExchangeRedisVersion>2.8.22</StackExchangeRedisVersion>
     <TimeZoneConverterVersion>6.1.0</TimeZoneConverterVersion>
     <AlibabaCloudDysmsapiVersion>3.0.0</AlibabaCloudDysmsapiVersion>


### PR DESCRIPTION
Repo-wide audit for #218/#219-era leftovers: no csproj/props/targets references NetMQVersion, GoogleProtobufVersion, GrpcNetClientVersion, GrpcAspNetCoreVersion, GrpcToolsVersion, MessagePackVersion (Messaging/Transport spun out to Vertex) or ScrutorVersion (reflection-scanning era). Removed all seven. Full solution build passes.

