### PR TITLE
test: serialize AppContext-switch tests to fix flaky reflection-fallback race

### DIFF
--- a/tests/Skywalker.Ddd.Tests/FeatureProviderRegistrationTests.cs
+++ b/tests/Skywalker.Ddd.Tests/FeatureProviderRegistrationTests.cs
@@ -230,6 +230,10 @@ public class UserDefinedFeatureProvider : IApplicationFeatureProvider<ServiceReg
 /// <summary>
 /// 验证 AddSkywalker() 一站式注册能自动发现 FeatureProvider 并正确注册所有服务。
 /// </summary>
+// 与 GeneratedRepositoryRegistrationBridgeTests 同一 collection 串行执行：
+// 该类会翻转进程级的 DisableReflectionRepositoryFallback 开关，本类的 AddSkywalkerDbContext
+// 测试依赖反射 fallback，并行执行会间歇性失败。
+[Collection("ReflectionRepositoryFallbackSwitch")]
 public class FeatureProviderRegistrationTests
 {
     private static ServiceProvider BuildProvider()

--- a/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
+++ b/tests/Skywalker.Ddd.Tests/GeneratedRepositoryRegistrationBridgeTests.cs
@@ -14,6 +14,9 @@ using Skywalker.Identity.Domain.Repositories;
 
 namespace Skywalker.Ddd.Tests;
 
+// 与 FeatureProviderRegistrationTests 同一 collection 串行执行：本类会翻转进程级的
+// DisableReflectionRepositoryFallback AppContext 开关，与依赖反射 fallback 的测试并行会间歇性失败。
+[Collection("ReflectionRepositoryFallbackSwitch")]
 public sealed class GeneratedRepositoryRegistrationBridgeTests
 {
     private const string DisableReflectionRepositoryFallbackSwitch = "Skywalker.Ddd.EntityFrameworkCore.DisableReflectionRepositoryFallback";


### PR DESCRIPTION
GeneratedRepositoryRegistrationBridgeTests flips the process-global DisableReflectionRepositoryFallback AppContext switch (with try/finally reset), but xUnit runs test classes in parallel, so FeatureProviderRegistrationTests' AddSkywalkerDbContext tests intermittently observe the switch enabled and fail with 'Reflection fallback is disabled' (seen on PR #305 where the 'test' workflow failed while 'Build and test' passed on the same commit). Put both classes in one xUnit collection so they run serially. Skywalker.Ddd.Tests: 79/79 locally.

