### PR TITLE
feat: add Skywalker.Sample.Website full-stack reference site

### DIFF
--- a/.github/workflows/sg-quality.yml
+++ b/.github/workflows/sg-quality.yml
@@ -87,6 +87,31 @@ jobs:
       - name: Run sample smoke test
         run: dotnet run --project samples/${{ matrix.sample }}/${{ matrix.sample }}.csproj --configuration Release --no-build
 
+  website-sample:
+    name: Sample Skywalker.Sample.Website
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore sample
+        run: dotnet restore samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Skywalker.Sample.Website.Web.csproj
+
+      - name: Build sample
+        run: dotnet build samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Skywalker.Sample.Website.Web.csproj --configuration Release --no-restore
+
+      - name: Run full-stack website smoke test
+        run: dotnet run --project samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Skywalker.Sample.Website.Web.csproj --configuration Release --no-build -- --smoke
+
   aot-publish:
     name: AOT publish canary
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Added
 
+- `Skywalker.Sample.Website` 全功能参考站点：按 DDD 四层（Domain/Application/EntityFrameworkCore/Web）组织的小型商城，组合全部功能族——EF SG 仓储、DI SG 注册、DynamicProxy 静态代理 + UoW 拦截、EventBus.Local 领域事件、Emailing/Sms（Null 投递）、Scriban 模板、JSON 本地化（中英）、Settings、Permissions、Caching、FluentValidation、HealthChecks、异常处理/响应包装中间件。带 20 项断言的进程内全栈 smoke（`--smoke`），已纳入 Source Generator Quality CI。
 - 运行时包捆绑 source generator analyzer（#298）：`Skywalker.Ddd.EntityFrameworkCore`、`Skywalker.Ddd.Abstractions`、`Skywalker.Extensions.DynamicProxies` 现在把各自的 SG analyzer DLL 打进包内 `analyzers/dotnet/cs`——只装运行时包的 NuGet 用户默认即获得零反射 generated registration / static proxies，不再静默落到反射 fallback（NativeAOT 下不再抛错）。独立的 `*.SourceGenerators` opt-in 包继续发布，显式引用者不受影响。
 - 架构依赖方向护栏：`eng/Check-ArchitectureDependencies.ps1` + `.github/workflows/arch-guard.yml`，CI 强制“除 `Skywalker.Ddd` 外一切不得反向依赖 `Skywalker.Ddd`、内核不得拉入增强家族、`Extensions.*` 保持最底层、内核依赖 EventBus 端口而非实现”等不变量，防止架构回归；`*.EntityFrameworkCore` 识别为合法 DDD 持久化适配器（#297，Epic #300）。
 - DI auto-registration Source Generator preview.5 首版 registration metadata 输出：属性标注服务会生成 `__SkywalkerDependencyInjectionRegistrar`，支持接口 fallback、显式 `ServiceType`、Scoped/Transient lifetime 映射，并对不可赋值服务类型报告 `SKY1002`（#280）。

--- a/Skywalker.sln
+++ b/Skywalker.sln
@@ -201,6 +201,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Emailing.Smtp.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Emailing.Abstractions", "src\Skywalker.Emailing.Abstractions\Skywalker.Emailing.Abstractions.csproj", "{39B2F3F8-5198-486D-9F7B-12A0929429D6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Skywalker.Sample.Website", "Skywalker.Sample.Website", "{00761F76-2A29-4958-955F-B17EF1878E7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Sample.Website.Domain", "samples\Skywalker.Sample.Website\Skywalker.Sample.Website.Domain\Skywalker.Sample.Website.Domain.csproj", "{6FF6F85F-4937-4606-B299-8688CAD6C325}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Sample.Website.Application", "samples\Skywalker.Sample.Website\Skywalker.Sample.Website.Application\Skywalker.Sample.Website.Application.csproj", "{652DE803-711F-40F2-9C9C-1ADD0F602B02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Sample.Website.EntityFrameworkCore", "samples\Skywalker.Sample.Website\Skywalker.Sample.Website.EntityFrameworkCore\Skywalker.Sample.Website.EntityFrameworkCore.csproj", "{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skywalker.Sample.Website.Web", "samples\Skywalker.Sample.Website\Skywalker.Sample.Website.Web\Skywalker.Sample.Website.Web.csproj", "{1532CC4B-3D01-484B-BC01-A4EC036621F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1339,6 +1349,54 @@ Global
 		{39B2F3F8-5198-486D-9F7B-12A0929429D6}.Release|x64.Build.0 = Release|Any CPU
 		{39B2F3F8-5198-486D-9F7B-12A0929429D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{39B2F3F8-5198-486D-9F7B-12A0929429D6}.Release|x86.Build.0 = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|x64.Build.0 = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Debug|x86.Build.0 = Debug|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|x64.ActiveCfg = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|x64.Build.0 = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|x86.ActiveCfg = Release|Any CPU
+		{6FF6F85F-4937-4606-B299-8688CAD6C325}.Release|x86.Build.0 = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|x64.Build.0 = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Debug|x86.Build.0 = Debug|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|x64.ActiveCfg = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|x64.Build.0 = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|x86.ActiveCfg = Release|Any CPU
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02}.Release|x86.Build.0 = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|x64.Build.0 = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE}.Release|x86.Build.0 = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|x64.Build.0 = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Debug|x86.Build.0 = Debug|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|x64.ActiveCfg = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|x64.Build.0 = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1440,6 +1498,11 @@ Global
 		{122E4C1C-BAE0-4CFF-A59B-13D0E362CD61} = {CAE4AA71-0C04-4DE4-BC63-54217950DE9A}
 		{D94EE184-5185-495C-A8FD-59484DE42CA4} = {CAE4AA71-0C04-4DE4-BC63-54217950DE9A}
 		{39B2F3F8-5198-486D-9F7B-12A0929429D6} = {F826DC92-8708-41A4-B0DF-0F3156254DCC}
+		{00761F76-2A29-4958-955F-B17EF1878E7C} = {54BB017B-1B7C-40C6-80FF-4499A62D1375}
+		{6FF6F85F-4937-4606-B299-8688CAD6C325} = {00761F76-2A29-4958-955F-B17EF1878E7C}
+		{652DE803-711F-40F2-9C9C-1ADD0F602B02} = {00761F76-2A29-4958-955F-B17EF1878E7C}
+		{5B4B5E40-DCDC-4300-AA4A-B7E3914F17EE} = {00761F76-2A29-4958-955F-B17EF1878E7C}
+		{1532CC4B-3D01-484B-BC01-A4EC036621F9} = {00761F76-2A29-4958-955F-B17EF1878E7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1448BD59-570D-4D37-831B-C0872E82B643}

--- a/samples/Skywalker.Sample.Website/README.md
+++ b/samples/Skywalker.Sample.Website/README.md
@@ -1,0 +1,44 @@
+# Skywalker.Sample.Website — 全功能参考站点
+
+一个小型商城站点，按 DDD 分层组织，**组合 Skywalker 的全部功能族**，是框架的端到端参考实现，也是 CI 的全栈冒烟门禁（`dotnet run -- --smoke`）。
+
+## 分层结构
+
+```
+Skywalker.Sample.Website.Domain              ← 聚合根（Member/Order）/实体/领域事件
+Skywalker.Sample.Website.Application         ← [ApplicationService] 应用服务/DTO/验证器/事件处理器（DI SG + DynamicProxy SG）
+Skywalker.Sample.Website.EntityFrameworkCore ← WebsiteDbContext（EF SG 生成仓储注册）
+Skywalker.Sample.Website.Web                 ← Host：Program.cs 组合全家桶 + MVC 控制器 + smoke
+```
+
+## 功能 → 框架能力映射
+
+| 站点功能 | 框架能力 |
+|---|---|
+| 会员注册 → 验证码短信 + 验证邮件 → 输码激活 | 聚合根领域事件 → EventBus.Local → `ISmsSender` + `IEmailSender` + Scriban 模板渲染 |
+| 商品目录（带缓存） | EF SG 仓储 + `ICachingProvider`（进程内实现，可换 Redis） |
+| 管理端改价（admin） | `IPermissionChecker` + 角色值提供者 + `ICurrentPrincipalAccessor` |
+| 下单 → 免邮计算 → 确认 → 确认邮件 | FluentValidation + `ISettingProvider` + `IPricingService` 静态代理拦截 + UoW 事务 + 提交后事件 |
+| 中英双语 | `IStringLocalizer<WebsiteResource>` + JSON 资源（VFS 嵌入） |
+| 错误契约 | 异常处理中间件/过滤器 + `AjaxResponse` 信封（`x-wrap-result: false` 取原始契约） |
+| 运维 | `MapSkywalkerHealthChecks()` |
+
+## 运行
+
+```bash
+# 常规启动（http://localhost:5000 由 ASP.NET Core 默认决定）
+dotnet run --project Skywalker.Sample.Website.Web
+
+# CI 自验证：进程内按真实用户路径打全部端点并断言（20 项）
+dotnet run --project Skywalker.Sample.Website.Web -- --smoke
+```
+
+演示认证：请求头 `X-Demo-User: u-1001`、`X-Demo-Roles: admin`（真实站点替换为 JWT/Cookie 认证，下游组件不感知差异）。
+
+## 值得注意的组合要点（踩坑记录）
+
+1. **`AddInterceptedServices()` 必须在 `AddSkywalkerDbContext` 之前**：EF SG 生成的 `IDomainService<,>` 闭合泛型注册暂无生成代理（见 #307）。
+2. 应用服务接口应继承 `Skywalker.Ddd.Application.Abstractions.IApplicationService`：UoW 中间件只**预留**工作单元，由静态代理上的 `UnitOfWorkInterceptor` 在应用服务方法边界接管。
+3. 单文件模板需 `WithVirtualFilePath(..., isInlineLocalized: true)`，并给 `TemplateDefinition` 指定 `LocalizationResource` 类型。
+4. Template/Settings/Permissions 的 options 类型列表按**具体类型**从 DI 解析，登记的引擎/贡献者/提供者需同时注册进 DI。
+5. `Localization.Json` 解析 `IFileProvider`，需把 `IVirtualFileProvider` 桥接注册。

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/AuditInterceptor.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/AuditInterceptor.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Skywalker.Extensions.DynamicProxies;
+
+namespace Skywalker.Sample.Website.Application;
+
+/// <summary>
+/// 审计拦截器：记录被代理服务的每次方法调用（smoke 验证用 Invocations 计数断言拦截生效）。
+/// </summary>
+public sealed class AuditInterceptor(ILogger<AuditInterceptor> logger) : IInterceptor
+{
+    public static ConcurrentQueue<string> Invocations { get; } = new();
+
+    public async Task InterceptAsync(IMethodInvocation invocation)
+    {
+        Invocations.Enqueue(invocation.MethodName);
+        logger.LogInformation("[Audit] {Method} invoked", invocation.MethodName);
+        await invocation.ProceedAsync();
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Dtos.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Dtos.cs
@@ -1,0 +1,19 @@
+namespace Skywalker.Sample.Website.Application;
+
+public record RegisterMemberInput(string Email, string Phone, string DisplayName);
+
+public record VerifyMemberInput(Guid MemberId, string Code);
+
+public record MemberDto(Guid Id, string Email, string Phone, string DisplayName, bool IsVerified);
+
+public record ProductDto(Guid Id, string Name, decimal Price, int Stock);
+
+public record UpdatePriceInput(decimal Price);
+
+public record PlaceOrderInput(string CustomerEmail, List<PlaceOrderItemInput> Items);
+
+public record PlaceOrderItemInput(Guid ProductId, int Quantity);
+
+public record OrderDto(Guid Id, string OrderNo, string CustomerEmail, decimal TotalAmount, decimal PayableAmount, string Status, List<OrderItemDto> Items);
+
+public record OrderItemDto(Guid ProductId, string ProductName, decimal UnitPrice, int Quantity);

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/EventHandlers.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/EventHandlers.cs
@@ -1,0 +1,67 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Skywalker.DependencyInjection;
+using Skywalker.Emailing;
+using Skywalker.EventBus.Abstractions;
+using Skywalker.Sample.Website.Domain;
+using Skywalker.Sms;
+using Skywalker.Sms.Abstractions;
+using Skywalker.Template.Abstractions;
+
+namespace Skywalker.Sample.Website.Application;
+
+/// <summary>
+/// smoke 验证用：记录事件处理器实际完成的动作。
+/// </summary>
+public static class NotificationLog
+{
+    public static ConcurrentQueue<string> Entries { get; } = new();
+}
+
+/// <summary>
+/// 会员注册事件处理器：事务提交后发送验证码短信（ISmsSender）
+/// 与验证邮件（模板由站点自己定义，Scriban 渲染后经 IEmailSender 发送）。
+/// </summary>
+[EventHandler]
+public sealed class MemberRegisteredEventHandler(
+    ISmsSender smsSender,
+    IEmailSender emailSender,
+    ITemplateRenderer templateRenderer,
+    ILogger<MemberRegisteredEventHandler> logger) : IEventHandler<MemberRegisteredEvent>
+{
+    public async Task HandleEventAsync(MemberRegisteredEvent eventData)
+    {
+        await smsSender.SendAsync(new SmsMessage(eventData.Phone, $"[Skywalker] 验证码：{eventData.VerificationCode}"));
+
+        var body = await templateRenderer.RenderAsync(
+            WebsiteTemplates.VerificationEmail,
+            new { name = eventData.DisplayName, code = eventData.VerificationCode });
+        await emailSender.SendAsync(eventData.Email, "请验证你的邮箱", body);
+
+        // 记录发出的验证码（真实场景在短信/邮件里；smoke 用它完成 注册→验证 闭环）
+        NotificationLog.Entries.Enqueue($"member-code:{eventData.MemberId}:{eventData.VerificationCode}");
+        NotificationLog.Entries.Enqueue($"member-registered:{eventData.MemberId}");
+        logger.LogInformation("Verification sms/email sent to {Email}", eventData.Email);
+    }
+}
+
+/// <summary>
+/// 订单确认事件处理器：渲染确认邮件模板并发送。
+/// </summary>
+[EventHandler]
+public sealed class OrderConfirmedEventHandler(
+    IEmailSender emailSender,
+    ITemplateRenderer templateRenderer,
+    ILogger<OrderConfirmedEventHandler> logger) : IEventHandler<OrderConfirmedEvent>
+{
+    public async Task HandleEventAsync(OrderConfirmedEvent eventData)
+    {
+        var body = await templateRenderer.RenderAsync(
+            WebsiteTemplates.OrderConfirmedEmail,
+            new { order_no = eventData.OrderNo, amount = eventData.TotalAmount });
+        await emailSender.SendAsync(eventData.CustomerEmail, $"订单 {eventData.OrderNo} 已确认", body);
+
+        NotificationLog.Entries.Enqueue($"order-confirmed:{eventData.OrderId}");
+        logger.LogInformation("Order confirmation email sent for {OrderNo}", eventData.OrderNo);
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/MemberAppService.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/MemberAppService.cs
@@ -1,0 +1,60 @@
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.DependencyInjection;
+using Skywalker.Sample.Website.Domain;
+using Skywalker.Validation;
+
+namespace Skywalker.Sample.Website.Application;
+
+/// <summary>
+/// 继承 IApplicationService：静态代理 + UnitOfWorkInterceptor 在方法边界接管
+/// 请求级工作单元（由 UoW 中间件预留），事务随方法完成提交。
+/// </summary>
+public interface IMemberAppService : Ddd.Application.Abstractions.IApplicationService
+{
+    Task<MemberDto> RegisterAsync(RegisterMemberInput input);
+    Task<MemberDto> VerifyAsync(VerifyMemberInput input);
+    Task<MemberDto?> FindAsync(Guid id);
+}
+
+/// <summary>
+/// 会员应用服务：注册时聚合根发出 MemberRegisteredEvent，
+/// 事务提交后由事件处理器发送验证码短信与验证邮件。
+/// </summary>
+[ApplicationService]
+internal sealed class MemberAppService(
+    IRepository<Member, Guid> members,
+    IValidator<RegisterMemberInput> registerValidator) : IMemberAppService
+{
+    public async Task<MemberDto> RegisterAsync(RegisterMemberInput input)
+    {
+        var validation = await registerValidator.ValidateAsync(input);
+        if (!validation.IsValid)
+        {
+            throw new Skywalker.Exceptions.SkywalkerValidationException(
+                string.Join("; ", validation.Errors.Select(error => error.ErrorMessage)));
+        }
+
+        var code = Random.Shared.Next(100000, 999999).ToString();
+        var member = new Member(Guid.NewGuid(), input.Email, input.Phone, input.DisplayName, code);
+
+        await members.InsertAsync(member, autoSave: true);
+        return ToDto(member);
+    }
+
+    public async Task<MemberDto> VerifyAsync(VerifyMemberInput input)
+    {
+        var member = await members.GetAsync(input.MemberId);
+        member.Verify(input.Code);
+        await members.UpdateAsync(member, autoSave: true);
+        return ToDto(member);
+    }
+
+    public async Task<MemberDto?> FindAsync(Guid id)
+    {
+        var member = await members.FindAsync(id);
+        return member is null ? null : ToDto(member);
+    }
+
+    private static MemberDto ToDto(Member member) =>
+        new(member.Id, member.Email, member.Phone, member.DisplayName, member.IsVerified);
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/OrderAppService.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/OrderAppService.cs
@@ -1,0 +1,78 @@
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.DependencyInjection;
+using Skywalker.Sample.Website.Domain;
+using Skywalker.Settings.Abstractions;
+using Skywalker.Validation;
+
+namespace Skywalker.Sample.Website.Application;
+
+public interface IOrderAppService : Ddd.Application.Abstractions.IApplicationService
+{
+    Task<OrderDto> PlaceAsync(PlaceOrderInput input);
+    Task<OrderDto> ConfirmAsync(Guid orderId);
+    Task<OrderDto?> FindAsync(Guid orderId);
+}
+
+/// <summary>
+/// 订单应用服务：FluentValidation 校验输入 → 聚合根封装业务不变量 →
+/// ISettingProvider 读免邮门槛 → IPricingService（静态代理拦截）算应付 →
+/// 确认后领域事件经事件总线发确认邮件。
+/// </summary>
+[ApplicationService]
+internal sealed class OrderAppService(
+    IRepository<Order, Guid> orders,
+    IRepository<Product, Guid> products,
+    IValidator<PlaceOrderInput> placeValidator,
+    ISettingProvider settings,
+    IPricingService pricing) : IOrderAppService
+{
+    public async Task<OrderDto> PlaceAsync(PlaceOrderInput input)
+    {
+        var validation = await placeValidator.ValidateAsync(input);
+        if (!validation.IsValid)
+        {
+            throw new Skywalker.Exceptions.SkywalkerValidationException(
+                string.Join("; ", validation.Errors.Select(error => error.ErrorMessage)));
+        }
+
+        var order = new Order(Guid.NewGuid(), $"SO-{Guid.NewGuid():N}"[..20].ToUpperInvariant(), input.CustomerEmail);
+
+        foreach (var item in input.Items)
+        {
+            var product = await products.GetAsync(item.ProductId);
+            order.AddItem(product, item.Quantity);
+        }
+
+        await orders.InsertAsync(order, autoSave: true);
+        return await ToDtoAsync(order);
+    }
+
+    public async Task<OrderDto> ConfirmAsync(Guid orderId)
+    {
+        var order = await orders.GetAsync(orderId);
+        order.Confirm();
+        await orders.UpdateAsync(order, autoSave: true);
+        return await ToDtoAsync(order);
+    }
+
+    public async Task<OrderDto?> FindAsync(Guid orderId)
+    {
+        var order = await orders.FindAsync(orderId);
+        return order is null ? null : await ToDtoAsync(order);
+    }
+
+    private async Task<OrderDto> ToDtoAsync(Order order)
+    {
+        var threshold = decimal.Parse(await settings.GetOrNullAsync(WebsiteSettings.FreeShippingThreshold) ?? "0");
+        var payable = await pricing.CalculatePayableAsync(order.TotalAmount, threshold);
+
+        return new OrderDto(
+            order.Id,
+            order.OrderNo,
+            order.CustomerEmail,
+            order.TotalAmount,
+            payable,
+            order.Status.ToString(),
+            order.Items.Select(i => new OrderItemDto(i.ProductId, i.ProductName, i.UnitPrice, i.Quantity)).ToList());
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/PricingService.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/PricingService.cs
@@ -1,0 +1,24 @@
+using Skywalker.DependencyInjection;
+using Skywalker.Extensions.DynamicProxies;
+
+namespace Skywalker.Sample.Website.Application;
+
+/// <summary>
+/// 定价服务：接口继承 IInterceptable，DynamicProxy SG 在编译期生成静态代理，
+/// AddInterceptedServices() 后所有调用经过 AuditInterceptor（零运行时 IL Emit）。
+/// </summary>
+public interface IPricingService : IInterceptable
+{
+    Task<decimal> CalculatePayableAsync(decimal totalAmount, decimal freeShippingThreshold);
+}
+
+[Service]
+internal sealed class PricingService : IPricingService
+{
+    public Task<decimal> CalculatePayableAsync(decimal totalAmount, decimal freeShippingThreshold)
+    {
+        // 满额免运费，否则加 10 元运费
+        var payable = totalAmount >= freeShippingThreshold ? totalAmount : totalAmount + 10m;
+        return Task.FromResult(payable);
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/ProductAppService.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/ProductAppService.cs
@@ -1,0 +1,62 @@
+using Skywalker.Caching.Abstractions;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.DependencyInjection;
+using Skywalker.Permissions.Abstractions;
+using Skywalker.Localization;
+using Skywalker.Sample.Website.Domain;
+using Skywalker.Security.Claims;
+
+namespace Skywalker.Sample.Website.Application;
+
+public interface IProductAppService : Ddd.Application.Abstractions.IApplicationService
+{
+    Task<List<ProductDto>> GetListAsync();
+    Task<ProductDto> UpdatePriceAsync(Guid productId, UpdatePriceInput input);
+}
+
+/// <summary>
+/// 商品应用服务：列表走 ICaching 缓存；改价是管理操作，
+/// 经 IPermissionChecker 校验当前用户（角色）持有 Website.Products.Manage 权限。
+/// </summary>
+[ApplicationService]
+internal sealed class ProductAppService(
+    IRepository<Product, Guid> products,
+    ICachingProvider cachingProvider,
+    IPermissionChecker permissionChecker,
+    ICurrentPrincipalAccessor principalAccessor,
+    IStringLocalizer<WebsiteResource> localizer) : IProductAppService
+{
+    private const string CacheName = "website:products";
+    private const string ListCacheKey = "all";
+
+    public async Task<List<ProductDto>> GetListAsync()
+    {
+        var caching = cachingProvider.GetCaching(CacheName);
+        var cached = await caching.GetAsync<List<ProductDto>>(ListCacheKey);
+        if (cached is not null)
+        {
+            return cached;
+        }
+
+        var list = await products.GetListAsync();
+        var dtos = list.Select(p => new ProductDto(p.Id, p.Name, p.Price, p.Stock)).ToList();
+        await caching.SetAsync(ListCacheKey, dtos, TimeSpan.FromMinutes(5));
+        return dtos;
+    }
+
+    public async Task<ProductDto> UpdatePriceAsync(Guid productId, UpdatePriceInput input)
+    {
+        var granted = await permissionChecker.IsGrantedAsync(principalAccessor.Principal, WebsitePermissions.ManageProducts);
+        if (!granted)
+        {
+            throw new Skywalker.Exceptions.AuthorizationException(localizer["Error:ManageProductsDenied"]);
+        }
+
+        var product = await products.GetAsync(productId);
+        product.Price = input.Price;
+        await products.UpdateAsync(product, autoSave: true);
+
+        cachingProvider.GetCaching(CacheName).Remove(ListCacheKey);
+        return new ProductDto(product.Id, product.Name, product.Price, product.Stock);
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Skywalker.Sample.Website.Application.csproj
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Skywalker.Sample.Website.Application.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Skywalker.Sample.Website.Domain\Skywalker.Sample.Website.Domain.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.Application\Skywalker.Ddd.Application.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.EventBus.Abstractions\Skywalker.EventBus.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Emailing.Abstractions\Skywalker.Emailing.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Sms.Abstractions\Skywalker.Sms.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Template.Abstractions\Skywalker.Template.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Caching.Abstractions\Skywalker.Caching.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Settings.Abstractions\Skywalker.Settings.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Localization.Abstractions\Skywalker.Localization.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Permissions.Abstractions\Skywalker.Permissions.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Validation.FluentValidation\Skywalker.Validation.FluentValidation.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Extensions.DynamicProxies\Skywalker.Extensions.DynamicProxies.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.Abstractions.SourceGenerators\Skywalker.Ddd.Abstractions.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Extensions.DynamicProxies.SourceGenerators\Skywalker.Extensions.DynamicProxies.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Validators.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/Validators.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace Skywalker.Sample.Website.Application;
+
+/// <summary>
+/// FluentValidation 验证器：AddFluentValidation&lt;T&gt;() 扫描本程序集自动注册，
+/// 同时桥接为 Skywalker.Validation.IValidator&lt;T&gt;。
+/// </summary>
+public sealed class RegisterMemberInputValidator : AbstractValidator<RegisterMemberInput>
+{
+    public RegisterMemberInputValidator()
+    {
+        RuleFor(input => input.Email).NotEmpty().EmailAddress();
+        RuleFor(input => input.Phone).NotEmpty().Matches(@"^\+?\d{6,15}$");
+        RuleFor(input => input.DisplayName).NotEmpty().MaximumLength(32);
+    }
+}
+
+public sealed class PlaceOrderInputValidator : AbstractValidator<PlaceOrderInput>
+{
+    public PlaceOrderInputValidator()
+    {
+        RuleFor(input => input.CustomerEmail).NotEmpty().EmailAddress();
+        RuleFor(input => input.Items).NotEmpty();
+        RuleForEach(input => input.Items).ChildRules(item =>
+        {
+            item.RuleFor(i => i.ProductId).NotEmpty();
+            item.RuleFor(i => i.Quantity).GreaterThan(0).LessThanOrEqualTo(99);
+        });
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/WebsiteConstants.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Application/WebsiteConstants.cs
@@ -1,0 +1,26 @@
+namespace Skywalker.Sample.Website.Application;
+
+public static class WebsitePermissions
+{
+    public const string ManageProducts = "Website.Products.Manage";
+}
+
+public static class WebsiteSettings
+{
+    /// <summary>免运费门槛（元）。</summary>
+    public const string FreeShippingThreshold = "Website.FreeShippingThreshold";
+
+    /// <summary>站点显示名。</summary>
+    public const string SiteName = "Website.SiteName";
+}
+
+public static class WebsiteTemplates
+{
+    public const string VerificationEmail = "Website.VerificationEmail";
+    public const string OrderConfirmedEmail = "Website.OrderConfirmedEmail";
+}
+
+/// <summary>本地化资源标记类型（资源内容在 Web 项目的 Localization/*.json）。</summary>
+public class WebsiteResource
+{
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Member.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Member.cs
@@ -1,0 +1,44 @@
+using Skywalker.Ddd.Domain.Entities;
+
+namespace Skywalker.Sample.Website.Domain;
+
+/// <summary>
+/// 会员聚合根：注册 → 发送验证码（短信/邮件）→ 验证激活。
+/// </summary>
+public class Member : AggregateRoot<Guid>
+{
+    public string Email { get; private set; } = string.Empty;
+    public string Phone { get; private set; } = string.Empty;
+    public string DisplayName { get; private set; } = string.Empty;
+    public string? VerificationCode { get; private set; }
+    public bool IsVerified { get; private set; }
+
+    protected Member() { }
+
+    public Member(Guid id, string email, string phone, string displayName, string verificationCode) : base(id)
+    {
+        Email = email;
+        Phone = phone;
+        DisplayName = displayName;
+        VerificationCode = verificationCode;
+        IsVerified = false;
+
+        AddDistributedEvent(new MemberRegisteredEvent(Id, Email, Phone, DisplayName, verificationCode));
+    }
+
+    public void Verify(string code)
+    {
+        if (IsVerified)
+        {
+            return;
+        }
+
+        if (!string.Equals(VerificationCode, code, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("验证码不正确");
+        }
+
+        IsVerified = true;
+        VerificationCode = null;
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/MemberRegisteredEvent.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/MemberRegisteredEvent.cs
@@ -1,0 +1,6 @@
+namespace Skywalker.Sample.Website.Domain;
+
+/// <summary>
+/// 会员注册领域事件：事务提交后发布，处理器负责发送验证码短信与验证邮件。
+/// </summary>
+public record MemberRegisteredEvent(Guid MemberId, string Email, string Phone, string DisplayName, string VerificationCode);

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Order.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Order.cs
@@ -1,0 +1,58 @@
+using Skywalker.Ddd.Domain.Entities;
+
+namespace Skywalker.Sample.Website.Domain;
+
+/// <summary>
+/// 订单聚合根：演示聚合封装、业务不变量与领域事件（AddDistributedEvent → EventBus）。
+/// </summary>
+public class Order : AggregateRoot<Guid>
+{
+    public string OrderNo { get; private set; } = string.Empty;
+    public string CustomerEmail { get; private set; } = string.Empty;
+    public decimal TotalAmount { get; private set; }
+    public OrderStatus Status { get; private set; }
+    public ICollection<OrderItem> Items { get; private set; } = new List<OrderItem>();
+
+    protected Order() { }
+
+    public Order(Guid id, string orderNo, string customerEmail) : base(id)
+    {
+        OrderNo = orderNo;
+        CustomerEmail = customerEmail;
+        Status = OrderStatus.Pending;
+    }
+
+    public void AddItem(Product product, int quantity)
+    {
+        if (Status != OrderStatus.Pending)
+        {
+            throw new InvalidOperationException("只有待处理订单可以添加商品");
+        }
+
+        Items.Add(new OrderItem(Guid.NewGuid(), Id, product.Id, product.Name, product.Price, quantity));
+        TotalAmount = Items.Sum(item => item.UnitPrice * item.Quantity);
+    }
+
+    public void Confirm()
+    {
+        if (Status != OrderStatus.Pending)
+        {
+            throw new InvalidOperationException("只有待处理订单可以确认");
+        }
+
+        if (Items.Count == 0)
+        {
+            throw new InvalidOperationException("订单必须包含至少一个商品");
+        }
+
+        Status = OrderStatus.Confirmed;
+        AddDistributedEvent(new OrderConfirmedEvent(Id, OrderNo, CustomerEmail, TotalAmount));
+    }
+}
+
+public enum OrderStatus
+{
+    Pending,
+    Confirmed,
+    Cancelled,
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/OrderConfirmedEvent.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/OrderConfirmedEvent.cs
@@ -1,0 +1,6 @@
+namespace Skywalker.Sample.Website.Domain;
+
+/// <summary>
+/// 订单确认领域事件：业务事务提交后经 IUnitOfWork.OnCompleted 发布到事件总线。
+/// </summary>
+public record OrderConfirmedEvent(Guid OrderId, string OrderNo, string CustomerEmail, decimal TotalAmount);

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/OrderItem.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/OrderItem.cs
@@ -1,0 +1,23 @@
+using Skywalker.Ddd.Domain.Entities;
+
+namespace Skywalker.Sample.Website.Domain;
+
+public class OrderItem : Entity<Guid>
+{
+    public Guid OrderId { get; private set; }
+    public Guid ProductId { get; private set; }
+    public string ProductName { get; private set; } = string.Empty;
+    public decimal UnitPrice { get; private set; }
+    public int Quantity { get; private set; }
+
+    protected OrderItem() { }
+
+    public OrderItem(Guid id, Guid orderId, Guid productId, string productName, decimal unitPrice, int quantity) : base(id)
+    {
+        OrderId = orderId;
+        ProductId = productId;
+        ProductName = productName;
+        UnitPrice = unitPrice;
+        Quantity = quantity;
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Product.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Product.cs
@@ -1,0 +1,22 @@
+using Skywalker.Ddd.Domain.Entities;
+
+namespace Skywalker.Sample.Website.Domain;
+
+/// <summary>
+/// 商品实体：演示 EF SG 自动仓储注册（IRepository&lt;Product, Guid&gt; 无需手写）。
+/// </summary>
+public class Product : Entity<Guid>
+{
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int Stock { get; set; }
+
+    protected Product() { }
+
+    public Product(Guid id, string name, decimal price, int stock) : base(id)
+    {
+        Name = name;
+        Price = price;
+        Stock = stock;
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Skywalker.Sample.Website.Domain.csproj
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Domain/Skywalker.Sample.Website.Domain.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.Domain\Skywalker.Ddd.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.EntityFrameworkCore/Skywalker.Sample.Website.EntityFrameworkCore.csproj
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.EntityFrameworkCore/Skywalker.Sample.Website.EntityFrameworkCore.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Skywalker.Sample.Website.Domain\Skywalker.Sample.Website.Domain.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.EntityFrameworkCore\Skywalker.Ddd.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators\Skywalker.Ddd.EntityFrameworkCore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.EntityFrameworkCore/WebsiteDbContext.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.EntityFrameworkCore/WebsiteDbContext.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Skywalker.Ddd.EntityFrameworkCore;
+using Skywalker.Sample.Website.Domain;
+
+namespace Skywalker.Sample.Website.EntityFrameworkCore;
+
+/// <summary>
+/// 站点 DbContext：EF SG 在编译期扫描 DbSet 生成 IRepository / IDomainService 注册。
+/// </summary>
+public class WebsiteDbContext(DbContextOptions<WebsiteDbContext> options) : SkywalkerDbContext<WebsiteDbContext>(options)
+{
+    public DbSet<Member> Members { get; set; } = default!;
+    public DbSet<Product> Products { get; set; } = default!;
+    public DbSet<Order> Orders { get; set; } = default!;
+    public DbSet<OrderItem> OrderItems { get; set; } = default!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Order>(order =>
+        {
+            order.HasMany(o => o.Items).WithOne().HasForeignKey(i => i.OrderId);
+            order.Navigation(o => o.Items).AutoInclude();
+        });
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Controllers.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Controllers.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Mvc;
+using Skywalker.Localization;
+using Skywalker.Sample.Website.Application;
+using Skywalker.Security.Users;
+using Skywalker.Settings.Abstractions;
+
+namespace Skywalker.Sample.Website.Web;
+
+[ApiController]
+public sealed class SiteController(
+    ISettingProvider settings,
+    IStringLocalizer<WebsiteResource> localizer,
+    ICurrentUser currentUser) : ControllerBase
+{
+    [HttpGet("/")]
+    public async Task<IActionResult> GetAsync() => Ok(new
+    {
+        site = await settings.GetOrNullAsync(WebsiteSettings.SiteName),
+        welcome = localizer["Welcome"].Value,
+    });
+
+    [HttpGet("/api/me")]
+    public IActionResult Me() => Ok(new
+    {
+        isAuthenticated = currentUser.IsAuthenticated,
+        userName = currentUser.Username,
+        roles = currentUser.Roles,
+    });
+}
+
+[ApiController]
+[Route("api/members")]
+public sealed class MembersController(IMemberAppService members) : ControllerBase
+{
+    [HttpPost("register")]
+    public async Task<IActionResult> RegisterAsync(RegisterMemberInput input) => Ok(await members.RegisterAsync(input));
+
+    [HttpPost("verify")]
+    public async Task<IActionResult> VerifyAsync(VerifyMemberInput input) => Ok(await members.VerifyAsync(input));
+}
+
+[ApiController]
+[Route("api/products")]
+public sealed class ProductsController(IProductAppService products) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetListAsync() => Ok(await products.GetListAsync());
+
+    [HttpPut("{id:guid}/price")]
+    public async Task<IActionResult> UpdatePriceAsync(Guid id, UpdatePriceInput input) => Ok(await products.UpdatePriceAsync(id, input));
+}
+
+[ApiController]
+[Route("api/orders")]
+public sealed class OrdersController(IOrderAppService orders) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> PlaceAsync(PlaceOrderInput input) => Ok(await orders.PlaceAsync(input));
+
+    [HttpPost("{id:guid}/confirm")]
+    public async Task<IActionResult> ConfirmAsync(Guid id) => Ok(await orders.ConfirmAsync(id));
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> FindAsync(Guid id) =>
+        await orders.FindAsync(id) is { } order ? Ok(order) : NotFound();
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/DataSeeder.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/DataSeeder.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Caching.Memory;
+using Skywalker.Ddd.Domain.Repositories;
+using Skywalker.Ddd.Uow;
+using Skywalker.Ddd.Uow.Abstractions;
+using Skywalker.Permissions;
+using Skywalker.Sample.Website.Application;
+using Skywalker.Sample.Website.Domain;
+
+namespace Skywalker.Sample.Website.Web.Infrastructure;
+
+public static class DataSeeder
+{
+    public static readonly Guid KeyboardId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    public static readonly Guid MouseId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        // 权限授予：admin 角色持有商品管理权限（写入 InMemoryPermissionValidator 的缓存）
+        var grants = new Dictionary<string, HashSet<(string, string)>>
+        {
+            [WebsitePermissions.ManageProducts] = [("R", "admin")],
+        };
+        services.GetRequiredService<IMemoryCache>().Set(InMemoryPermissionValidator.GrantsCacheKey, grants);
+
+        // 商品种子：仓储必须在工作单元内使用，启动期手动开启 UoW
+        using var scope = services.CreateScope();
+        var unitOfWorkManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+        using var unitOfWork = unitOfWorkManager.Begin(new UnitOfWorkOptions());
+
+        var products = scope.ServiceProvider.GetRequiredService<IRepository<Product, Guid>>();
+        await products.InsertAsync(new Product(KeyboardId, "机械键盘", 399m, 100));
+        await products.InsertAsync(new Product(MouseId, "无线鼠标", 129m, 200));
+
+        await unitOfWork.CompleteAsync();
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/HttpContextCurrentPrincipalAccessor.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/HttpContextCurrentPrincipalAccessor.cs
@@ -1,0 +1,56 @@
+using System.Security.Claims;
+using Skywalker.Security.Claims;
+
+namespace Skywalker.Sample.Website.Web.Infrastructure;
+
+/// <summary>
+/// 让 Security 家族的 ICurrentUser / 权限检查读取 HttpContext.User。
+/// </summary>
+public sealed class HttpContextCurrentPrincipalAccessor(IHttpContextAccessor httpContextAccessor) : ICurrentPrincipalAccessor
+{
+    private static readonly AsyncLocal<ClaimsPrincipal?> s_override = new();
+
+    public ClaimsPrincipal? Principal => s_override.Value ?? httpContextAccessor.HttpContext?.User;
+
+    public IDisposable Change(ClaimsPrincipal principal)
+    {
+        var previous = s_override.Value;
+        s_override.Value = principal;
+        return new DisposeAction(() => s_override.Value = previous);
+    }
+
+    private sealed class DisposeAction(Action action) : IDisposable
+    {
+        public void Dispose() => action();
+    }
+}
+
+/// <summary>
+/// 演示认证中间件：从 X-Demo-User / X-Demo-Roles 请求头构造 ClaimsPrincipal。
+/// 真实站点替换为 JWT/Cookie 等标准认证即可，下游组件（ICurrentUser/权限）不感知差异。
+/// </summary>
+public sealed class DemoAuthenticationMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var user = context.Request.Headers["X-Demo-User"].ToString();
+        if (!string.IsNullOrEmpty(user))
+        {
+            var claims = new List<Claim>
+            {
+                new(SkywalkerClaimTypes.UserId, user),
+                new(SkywalkerClaimTypes.UserName, user),
+            };
+
+            foreach (var role in context.Request.Headers["X-Demo-Roles"].ToString()
+                         .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                claims.Add(new Claim(SkywalkerClaimTypes.Role, role));
+            }
+
+            context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Demo"));
+        }
+
+        await next(context);
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/MemoryCachingProvider.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/MemoryCachingProvider.cs
@@ -1,0 +1,143 @@
+using System.Collections.Concurrent;
+using Skywalker.Caching.Abstractions;
+
+namespace Skywalker.Sample.Website.Web.Infrastructure;
+
+/// <summary>
+/// 进程内内存缓存 provider：演示 Caching 家族的扩展点
+/// （生产环境换 Skywalker.Caching.Redis 的 AddRedisCaching 即可，消费方代码不变）。
+/// </summary>
+public sealed class MemoryCachingProvider : CachingProvider
+{
+    protected override ICaching CreateCacheImplementation(string name) => new MemoryCaching(name);
+}
+
+internal sealed class MemoryCaching(string name) : ICaching
+{
+    private sealed record Entry(object? Value, DateTimeOffset? ExpiresAt)
+    {
+        public bool IsExpired => ExpiresAt.HasValue && ExpiresAt.Value <= DateTimeOffset.UtcNow;
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _store = new();
+
+    public string Name { get; } = name;
+
+    public TimeSpan? DefaultExpireTime { get; set; } = TimeSpan.FromHours(1);
+
+    private Entry? GetEntry(string key)
+    {
+        if (_store.TryGetValue(key, out var entry))
+        {
+            if (!entry.IsExpired)
+            {
+                return entry;
+            }
+
+            _store.TryRemove(key, out _);
+        }
+
+        return null;
+    }
+
+    private void SetEntry(string key, object? value, TimeSpan? expireTime)
+    {
+        var expiry = expireTime ?? DefaultExpireTime;
+        _store[key] = new Entry(value, expiry.HasValue ? DateTimeOffset.UtcNow.Add(expiry.Value) : null);
+    }
+
+    public byte[]? Get(string key) => GetEntry(key)?.Value as byte[];
+
+    public ValueTask<byte[]?> GetAsync(string key, CancellationToken cancellationToken = default) => ValueTask.FromResult(Get(key));
+
+    public TValue? Get<TValue>(string key) => GetEntry(key)?.Value is TValue value ? value : default;
+
+    public ValueTask<TValue?> GetAsync<TValue>(string key, CancellationToken cancellationToken = default) => ValueTask.FromResult(Get<TValue>(key));
+
+    public IEnumerable<TValue?> GetMany<TValue>(IEnumerable<string> keys) => keys.Select(Get<TValue>);
+
+    public ValueTask<IEnumerable<TValue?>> GetManyAsync<TValue>(IEnumerable<string> keys, CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(GetMany<TValue>(keys));
+
+    public void Set(string key, byte[] value, TimeSpan? expireTime = null) => SetEntry(key, value, expireTime);
+
+    public Task SetAsync(string key, byte[] value, TimeSpan? expireTime = null, CancellationToken cancellationToken = default)
+    {
+        Set(key, value, expireTime);
+        return Task.CompletedTask;
+    }
+
+    public void Set<TValue>(string key, TValue value, TimeSpan? expireTime = null) => SetEntry(key, value, expireTime);
+
+    public Task SetAsync<TValue>(string key, TValue value, TimeSpan? expireTime = null, CancellationToken cancellationToken = default)
+    {
+        Set(key, value, expireTime);
+        return Task.CompletedTask;
+    }
+
+    public void SetMany<TValue>(IEnumerable<KeyValuePair<string, TValue>> items, TimeSpan? expireTime = null)
+    {
+        foreach (var item in items)
+        {
+            Set(item.Key, item.Value, expireTime);
+        }
+    }
+
+    public Task SetManyAsync<TValue>(IEnumerable<KeyValuePair<string, TValue>> items, TimeSpan? expireTime = null, CancellationToken cancellationToken = default)
+    {
+        SetMany(items, expireTime);
+        return Task.CompletedTask;
+    }
+
+    public TValue GetOrSet<TValue>(string key, Func<TValue> factory)
+    {
+        if (GetEntry(key)?.Value is TValue cached)
+        {
+            return cached;
+        }
+
+        var value = factory();
+        Set(key, value);
+        return value;
+    }
+
+    public async ValueTask<TValue> GetOrSetAsync<TValue>(string key, Func<Task<TValue>> factory, CancellationToken cancellationToken = default)
+    {
+        if (GetEntry(key)?.Value is TValue cached)
+        {
+            return cached;
+        }
+
+        var value = await factory();
+        Set(key, value);
+        return value;
+    }
+
+    public void Remove(string key) => _store.TryRemove(key, out _);
+
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Remove(key);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveManyAsync(string[] keys, CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+        {
+            Remove(key);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Clear() => _store.Clear();
+
+    public Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        Clear();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _store.Clear();
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/SmokeRunner.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/SmokeRunner.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Skywalker.Sample.Website.Application;
+using Skywalker.Sample.Website.Domain;
+
+namespace Skywalker.Sample.Website.Web.Infrastructure;
+
+/// <summary>
+/// CI 自验证：对进程内站点按真实用户路径打一遍请求，
+/// 断言 注册→短信/邮件→浏览(缓存)→权限→下单(验证/设置/代理)→确认→事件邮件 全链路。
+/// </summary>
+public static class SmokeRunner
+{
+    public static async Task<int> RunAsync(WebApplication app)
+    {
+        var baseAddress = app.Urls.First();
+        using var client = new HttpClient { BaseAddress = new Uri(baseAddress) };
+        // 默认请求原始契约（关闭 AjaxResponse 包装）；信封行为单独断言
+        client.DefaultRequestHeaders.Add("x-wrap-result", "false");
+        var failures = new List<string>();
+
+        void Ensure(bool condition, string check)
+        {
+            if (!condition)
+            {
+                failures.Add(check);
+                Console.Error.WriteLine($"SMOKE FAIL: {check}");
+            }
+            else
+            {
+                Console.WriteLine($"smoke ok: {check}");
+            }
+        }
+
+        // 0. 事件总线连通性（直接调用处理器，暴露被消费循环吞掉的异常）
+        try
+        {
+            var probeHandler = ActivatorUtilities.CreateInstance<MemberRegisteredEventHandler>(app.Services);
+            await probeHandler.HandleEventAsync(new MemberRegisteredEvent(Guid.Empty, "probe@example.com", "+8613800000000", "probe", "000000"));
+            Ensure(NotificationLog.Entries.Contains($"member-registered:{Guid.Empty}"), "handler executes (direct invocation)");
+        }
+        catch (Exception probeException)
+        {
+            Ensure(false, $"handler executes (direct invocation): {probeException}");
+        }
+
+        // 1. 站点信息：Settings 默认值 + 英文本地化
+        var home = await client.GetFromJsonAsync<JsonElement>("/");
+        Ensure(home.GetProperty("site").GetString() == "Skywalker Shop", "settings default value served");
+        Ensure(home.GetProperty("welcome").GetString() == "Welcome to Skywalker Shop", $"localization en (actual: {home.GetProperty("welcome").GetString()})");
+
+        // 2. 中文本地化（Accept-Language）
+        using (var request = new HttpRequestMessage(HttpMethod.Get, "/"))
+        {
+            request.Headers.Add("Accept-Language", "zh-CN");
+            var zh = await (await client.SendAsync(request)).Content.ReadFromJsonAsync<JsonElement>();
+            Ensure(zh.GetProperty("welcome").GetString() == "欢迎光临 Skywalker 商城", $"localization zh-CN (actual: {zh.GetProperty("welcome").GetString()})");
+        }
+
+        // 2b. AjaxResponse 信封：不带 x-wrap-result:false 时错误响应被包装为 200 + 信封
+        using (var wrappedClient = new HttpClient { BaseAddress = new Uri(baseAddress) })
+        {
+            var wrapped = await wrappedClient.PostAsJsonAsync("/api/members/register", new RegisterMemberInput("bad", "1", ""));
+            Ensure(wrapped.StatusCode == HttpStatusCode.OK && wrapped.Headers.Contains("x-wrap-result"),
+                "error wrapped as AjaxResponse envelope by default");
+        }
+
+        // 3. 会员注册：非法输入 → ExceptionFilter 包装为 AjaxResponse（success=false）
+        var badRegister = await client.PostAsJsonAsync("/api/members/register", new RegisterMemberInput("not-an-email", "123", ""));
+        var badBody = await badRegister.Content.ReadFromJsonAsync<JsonElement>();
+        Ensure(!badBody.GetProperty("success").GetBoolean() && badBody.GetProperty("error").ValueKind == JsonValueKind.Object,
+            "invalid register rejected via validation envelope");
+
+        // 4. 会员注册：合法 → 事件处理器发验证码短信 + 验证邮件
+        var register = await client.PostAsJsonAsync("/api/members/register", new RegisterMemberInput("alice@example.com", "+8613800000000", "Alice"));
+        Ensure(register.IsSuccessStatusCode, "member registered");
+        var member = await register.Content.ReadFromJsonAsync<JsonElement>();
+        var memberId = member.GetProperty("id").GetGuid();
+
+        await WaitUntilAsync(() => NotificationLog.Entries.Contains($"member-registered:{memberId}"));
+        Ensure(NotificationLog.Entries.Contains($"member-registered:{memberId}"), "registration event handled (sms+email sent)");
+
+        // 4b. 用短信里的验证码完成验证（注册 → 验证 闭环）
+        var verificationCode = NotificationLog.Entries
+            .FirstOrDefault(e => e.StartsWith($"member-code:{memberId}:"))?.Split(':')[2];
+        var verify = await client.PostAsJsonAsync("/api/members/verify", new VerifyMemberInput(memberId, verificationCode ?? string.Empty));
+        var verified = await verify.Content.ReadFromJsonAsync<JsonElement>();
+        Ensure(verified.GetProperty("isVerified").GetBoolean(), "member verified with sms code");
+
+        // 5. 商品列表：两次调用第二次命中缓存
+        var products1 = await client.GetFromJsonAsync<JsonElement>("/api/products");
+        Ensure(products1.GetArrayLength() == 2, "product list served");
+        var products2 = await client.GetFromJsonAsync<JsonElement>("/api/products");
+        Ensure(products2.GetArrayLength() == 2, "product list cached");
+
+        // 6. 权限：匿名改价 → AuthorizationException 信封（unAuthorizedRequest=true）；admin 角色改价 → 成功
+        var denied = await client.PutAsJsonAsync($"/api/products/{DataSeeder.KeyboardId}/price", new UpdatePriceInput(499m));
+        var deniedRaw = await denied.Content.ReadAsStringAsync();
+        var deniedBody = JsonSerializer.Deserialize<JsonElement>(deniedRaw);
+        // 当前 ExceptionFilter 的错误转换只保留 UserFriendlyException 的 code，其余 masked；断言信封语义
+        Ensure(!deniedBody.GetProperty("success").GetBoolean()
+               && deniedBody.GetProperty("error").ValueKind == JsonValueKind.Object,
+            $"anonymous price update denied (actual: {deniedRaw})");
+
+        using (var request = new HttpRequestMessage(HttpMethod.Put, $"/api/products/{DataSeeder.KeyboardId}/price"))
+        {
+            request.Headers.Add("X-Demo-User", "u-1001");
+            request.Headers.Add("X-Demo-Roles", "admin");
+            request.Content = JsonContent.Create(new UpdatePriceInput(499m));
+            var updated = await client.SendAsync(request);
+            Ensure(updated.IsSuccessStatusCode, "admin price update granted");
+        }
+
+        // 7. 当前用户（Security / ICurrentUser）
+        using (var request = new HttpRequestMessage(HttpMethod.Get, "/api/me"))
+        {
+            request.Headers.Add("X-Demo-User", "u-1001");
+            request.Headers.Add("X-Demo-Roles", "admin");
+            var me = await (await client.SendAsync(request)).Content.ReadFromJsonAsync<JsonElement>();
+            Ensure(me.GetProperty("isAuthenticated").GetBoolean(), "current user authenticated");
+        }
+
+        // 8. 下单：验证 + 免邮门槛设置 + 静态代理定价
+        var placed = await client.PostAsJsonAsync("/api/orders", new PlaceOrderInput("alice@example.com",
+            [new PlaceOrderItemInput(DataSeeder.KeyboardId, 1)]));
+        Ensure(placed.IsSuccessStatusCode, "order placed");
+        var order = await placed.Content.ReadFromJsonAsync<JsonElement>();
+        var orderId = order.GetProperty("id").GetGuid();
+        // 499 >= 免邮门槛 99 → 应付 = 总额（免运费）
+        Ensure(order.GetProperty("payableAmount").GetDecimal() == order.GetProperty("totalAmount").GetDecimal(), "free shipping applied via settings+proxy");
+        Ensure(AuditInterceptor.Invocations.Contains("CalculatePayableAsync"), "interceptor audited proxied call");
+
+        // 9. 确认订单 → 事务提交后事件处理器渲染模板并发确认邮件
+        var confirmed = await client.PostAsync($"/api/orders/{orderId}/confirm", content: null);
+        Ensure(confirmed.IsSuccessStatusCode, "order confirmed");
+        await WaitUntilAsync(() => NotificationLog.Entries.Contains($"order-confirmed:{orderId}"));
+        Ensure(NotificationLog.Entries.Contains($"order-confirmed:{orderId}"), "confirmation event handled (templated email sent)");
+
+        // 10. 健康检查
+        var health = await client.GetAsync("/health");
+        Ensure(health.IsSuccessStatusCode, "health endpoint");
+
+        return failures.Count == 0 ? 0 : 1;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 5000)
+    {
+        var start = Environment.TickCount64;
+        while (!condition() && Environment.TickCount64 - start < timeoutMs)
+        {
+            await Task.Delay(50);
+        }
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/WebsiteDefinitionProviders.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Infrastructure/WebsiteDefinitionProviders.cs
@@ -1,0 +1,46 @@
+using Skywalker.Permissions;
+using Skywalker.Permissions.Abstractions;
+using Skywalker.Sample.Website.Application;
+using Skywalker.Settings;
+using Skywalker.Settings.Abstractions;
+using Skywalker.Template;
+using Skywalker.Template.Abstractions;
+
+namespace Skywalker.Sample.Website.Web.Infrastructure;
+
+/// <summary>站点权限定义。</summary>
+public sealed class WebsitePermissionDefinitionProvider : IPermissionDefinitionProvider
+{
+    public void Define(PermissionDefinitionContext context)
+    {
+        context.AddPermission(WebsitePermissions.ManageProducts, "管理商品");
+    }
+}
+
+/// <summary>站点设置定义（默认值即 DefaultValueSettingValueProvider 的取值来源）。</summary>
+public sealed class WebsiteSettingDefinitionProvider : SettingDefinitionProvider
+{
+    public override void Define(ISettingDefinitionContext context)
+    {
+        context.Add(new SettingDefinition(WebsiteSettings.FreeShippingThreshold, defaultValue: "99"));
+        context.Add(new SettingDefinition(WebsiteSettings.SiteName, defaultValue: "Skywalker Shop"));
+    }
+}
+
+/// <summary>
+/// 站点邮件模板定义：模板内容是站点资产（嵌入资源），
+/// 用什么模板、什么内容完全由站点决定，框架只提供渲染管线。
+/// </summary>
+public sealed class WebsiteTemplateDefinitionProvider : TemplateDefinitionProvider
+{
+    public override void Define(ITemplateDefinitionContext context)
+    {
+        // 单文件模板必须 isInlineLocalized: true——内容提供器只在 inline-localized 模式下
+        // 才会用 culture 无关方式读取单文件内容
+        context.Add(new TemplateDefinition(WebsiteTemplates.VerificationEmail, typeof(WebsiteResource))
+            .WithVirtualFilePath("/Templates/VerificationEmail.tpl", isInlineLocalized: true));
+
+        context.Add(new TemplateDefinition(WebsiteTemplates.OrderConfirmedEmail, typeof(WebsiteResource))
+            .WithVirtualFilePath("/Templates/OrderConfirmedEmail.tpl", isInlineLocalized: true));
+    }
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Localization/en.json
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Localization/en.json
@@ -1,0 +1,1 @@
+﻿{"Error:ManageProductsDenied": "You are not allowed to manage products.", "Welcome": "Welcome to Skywalker Shop"}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Localization/zh-CN.json
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Localization/zh-CN.json
@@ -1,0 +1,1 @@
+﻿{"Error:ManageProductsDenied": "你没有商品管理权限。", "Welcome": "欢迎光临 Skywalker 商城"}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Program.cs
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Program.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Skywalker.Caching.Abstractions;
+using Skywalker.Extensions.DynamicProxies;
+using Skywalker.Extensions.VirtualFileSystem;
+using Skywalker.Localization;
+using Skywalker.Localization.AspNetCore;
+using Skywalker.Localization.Json;
+using Skywalker.Permissions;
+using Skywalker.Permissions.Abstractions;
+using Skywalker.Sample.Website.Application;
+using Skywalker.Sample.Website.EntityFrameworkCore;
+using Skywalker.Sample.Website.Web.Infrastructure;
+using Skywalker.Security.Claims;
+using Skywalker.Security.Users;
+using Skywalker.Settings.Abstractions;
+using Skywalker.Settings;
+using Microsoft.EntityFrameworkCore;
+
+var smoke = args.Contains("--smoke");
+
+var builder = WebApplication.CreateBuilder(args);
+if (smoke)
+{
+    builder.WebHost.UseUrls("http://127.0.0.1:0");
+}
+
+var services = builder.Services;
+
+// ── DDD 内核 + DI SG（[ApplicationService]/[Service]/[EventHandler] 编译期生成注册）──
+services.AddSkywalker(typeof(Program).Assembly)
+    .AddAspNetCore();
+
+// ── 拦截器（DynamicProxy SG 静态代理）──
+// 注意：需在 AddSkywalkerDbContext 之前调用——AddInterceptedServices 只代理此刻已注册、
+// 且拥有生成代理的服务；EF SG 生成的 IDomainService<,> 闭合泛型注册暂无代理支持（见 #307）。
+services.AddTransient<IInterceptor, AuditInterceptor>();
+services.AddInterceptedServices();
+
+// ── EF Core：EF SG 生成仓储/领域服务注册（零反射）──
+services.AddSkywalkerDbContext<WebsiteDbContext>(options =>
+{
+    options.Configure(context => context.DbContextOptions.UseInMemoryDatabase("Skywalker.Sample.Website"));
+});
+
+// ── 事件总线（本地 channel）：订阅领域事件处理器 ──
+services.AddTransient<MemberRegisteredEventHandler>();
+services.AddTransient<OrderConfirmedEventHandler>();
+services.AddEventBusLocal(options =>
+{
+    options.AddEventHandler<MemberRegisteredEventHandler>();
+    options.AddEventHandler<OrderConfirmedEventHandler>();
+});
+
+// ── 邮件（NullEmailSender 兜底，生产换 AddSmtpEmailing）/ 短信（NullSmsSender）──
+services.AddEmailing(options =>
+{
+    options.DefaultFromAddress = "noreply@shop.local";
+    options.DefaultFromDisplayName = "Skywalker Shop";
+});
+services.AddSms();
+
+// ── 虚拟文件系统 + 模板引擎（Scriban）：模板内容是站点资产（嵌入资源）──
+services.AddVirtualFileSystem();
+services.Configure<SkywalkerVirtualFileSystemOptions>(options =>
+{
+    options.FileSets.AddEmbedded<Program>(baseNamespace: "Skywalker.Sample.Website.Web");
+});
+// Localization.Json 解析的是 IFileProvider，把 VFS 桥接过去
+services.AddSingleton<Microsoft.Extensions.FileProviders.IFileProvider>(sp => sp.GetRequiredService<IVirtualFileProvider>());
+services.AddTemplate(options =>
+{
+    options.DefinitionProviders.Add<WebsiteTemplateDefinitionProvider>();
+    options.ContentContributors.Add<Skywalker.Template.VirtualFiles.VirtualFileTemplateContentContributor>();
+});
+services.AddScribanTemplate();
+// Template 管线按具体类型从 DI 解析 options 里登记的引擎/贡献者，补注册具体类型
+services.AddTransient<Skywalker.Template.Scriban.ScribanTemplateRenderingEngine>();
+services.AddTransient<Skywalker.Template.VirtualFiles.VirtualFileTemplateContentContributor>();
+services.AddSingleton<WebsiteTemplateDefinitionProvider>();
+
+// ── 本地化（JSON 资源，中英双语）──
+// Scriban 模板引擎依赖微软的 IStringLocalizerFactory，两套本地化并存
+services.AddLocalization();
+services.AddSkywalkerLocalization(options =>
+{
+    options.DefaultResourceType = typeof(WebsiteResource);
+    options.Resources.Add<WebsiteResource>("en").AddJson("/Localization");
+    options.Languages.Add(new LanguageInfo("en", "English", isDefault: true));
+    options.Languages.Add(new LanguageInfo("zh-CN", "简体中文"));
+});
+
+// ── 设置（定义默认值 + appsettings 覆盖）──
+services.AddSettings(options =>
+{
+    options.ValueProviders.Add<ConfigurationSettingValueProvider>();
+    options.ValueProviders.Add<DefaultValueSettingValueProvider>();
+});
+services.AddSingleton<ISettingDefinitionProvider, WebsiteSettingDefinitionProvider>();
+
+// ── 权限（角色/用户值提供者 + 内存授权）──
+services.AddPermissions();
+services.Configure<PermissionOptions>(options =>
+{
+    options.DefinitionProviders.Add<WebsitePermissionDefinitionProvider>();
+    options.ValueProviders.Add<RolePermissionValueProvider>();
+    options.ValueProviders.Add<UserPermissionValueProvider>();
+});
+services.AddSingleton<WebsitePermissionDefinitionProvider>();
+services.AddSingleton<RolePermissionValueProvider>();
+services.AddSingleton<UserPermissionValueProvider>();
+
+// ── 安全（ICurrentUser 读取 HttpContext.User）──
+services.AddSecurity();
+services.AddHttpContextAccessor();
+services.Replace(ServiceDescriptor.Singleton<ICurrentPrincipalAccessor, HttpContextCurrentPrincipalAccessor>());
+
+// ── 验证（FluentValidation 扫描 Application 程序集）──
+services.AddFluentValidation<PlaceOrderInputValidator>();
+
+// ── 缓存（进程内实现；生产换 AddRedisCaching）──
+services.AddSingleton<ICachingProvider, MemoryCachingProvider>();
+
+// ── 健康检查 ──
+services.AddSkywalkerHealthChecks();
+
+// ── MVC 控制器（UoW 中间件按 ActionDescriptor 识别工作单元边界；响应经 ResultFilter 包装为 AjaxResponse）──
+services.AddControllers();
+
+var app = builder.Build();
+
+await DataSeeder.SeedAsync(app.Services);
+
+// ── 中间件管线：请求本地化 → 演示认证 → 异常处理 + 工作单元 ──
+app.UseSkywalkerRequestLocalization();
+app.UseMiddleware<DemoAuthenticationMiddleware>();
+app.UseSkywalker();
+
+// ── 端点（见 Controllers.cs）──
+app.MapControllers();
+app.MapSkywalkerHealthChecks();
+
+if (!smoke)
+{
+    await app.RunAsync();
+    return 0;
+}
+
+// ── smoke 模式：进程内跑通全站流程并断言 ──
+await app.StartAsync();
+try
+{
+    var exitCode = await SmokeRunner.RunAsync(app);
+    Console.WriteLine(exitCode == 0
+        ? "Sample: Website — full-stack smoke passed."
+        : "Sample: Website — smoke FAILED.");
+    return exitCode;
+}
+finally
+{
+    await app.StopAsync();
+}

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Skywalker.Sample.Website.Web.csproj
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Skywalker.Sample.Website.Web.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Skywalker.Sample.Website.Application\Skywalker.Sample.Website.Application.csproj" />
+    <ProjectReference Include="..\Skywalker.Sample.Website.EntityFrameworkCore\Skywalker.Sample.Website.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.AspNetCore\Skywalker.Ddd.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.EventBus.Local\Skywalker.EventBus.Local.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Template.Scriban\Skywalker.Template.Scriban.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Localization.AspNetCore\Skywalker.Localization.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Localization.Json\Skywalker.Localization.Json.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Permissions\Skywalker.Permissions.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Security\Skywalker.Security.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Extensions.VirtualFileSystem\Skywalker.Extensions.VirtualFileSystem.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.HealthChecks.AspNetCore\Skywalker.HealthChecks.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Skywalker.Ddd.Abstractions.SourceGenerators\Skywalker.Ddd.Abstractions.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Templates\*.tpl" />
+    <EmbeddedResource Include="Localization\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Templates/OrderConfirmedEmail.tpl
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Templates/OrderConfirmedEmail.tpl
@@ -1,0 +1,1 @@
+﻿<h1>订单已确认</h1><p>订单号 {{ model.order_no }}，金额 {{ model.amount }} 元，我们将尽快发货。</p>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Templates/VerificationEmail.tpl
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/Templates/VerificationEmail.tpl
@@ -1,0 +1,1 @@
+﻿<h1>你好 {{ model.name }}</h1><p>你的验证码是 <strong>{{ model.code }}</strong>，10 分钟内有效。</p>

--- a/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/appsettings.json
+++ b/samples/Skywalker.Sample.Website/Skywalker.Sample.Website.Web/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "ConnectionStrings": {
+    "Default": "Skywalker.Sample.Website"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary

Adds **`Skywalker.Sample.Website`** — a small shop website organized in DDD layers that composes **every feature family** end-to-end, serving as the framework's reference implementation and a 20-assertion full-stack CI smoke gate.

```
Skywalker.Sample.Website.Domain              ← Member/Order/Product aggregates + domain events
Skywalker.Sample.Website.Application         ← [ApplicationService] services, validators, interceptor, event handlers (DI SG + Proxy SG)
Skywalker.Sample.Website.EntityFrameworkCore ← WebsiteDbContext (EF SG)
Skywalker.Sample.Website.Web                 ← Host: full composition, MVC controllers, smoke runner
```

## Feature → capability map

| Site flow | Framework capabilities exercised |
|---|---|
| Register → verification sms + templated email → verify with code | Aggregate domain events → EventBus.Local → `ISmsSender` / `IEmailSender` + Scriban `ITemplateRenderer` (templates are site assets) |
| Product catalog with caching | EF SG repositories + `ICachingProvider` (in-process impl; Redis-swappable) |
| Admin price update | `IPermissionChecker` + role value provider + in-memory grants + `ICurrentUser` over HttpContext |
| Place order → free-shipping threshold → confirm → confirmation email | FluentValidation + `ISettingProvider` + `IPricingService` static proxy (AuditInterceptor) + per-request UoW + post-commit event |
| Bilingual (en/zh-CN) | `IStringLocalizer<WebsiteResource>` + JSON resources via VFS embedded files |
| Error contract | Exception middleware/filter + `AjaxResponse` envelope (raw contract via `x-wrap-result: false`) |
| Ops | `MapSkywalkerHealthChecks()` |

CI: dedicated `website-sample` job in Source Generator Quality runs `dotnet run -- --smoke` (20 in-process assertions across the whole user journey).

## Framework rough edges surfaced (worked around with comments; follow-up issues to file)

1. `AddInterceptedServices()` + EF SG throws at startup for generated `IDomainService<,>` closed-generic registrations (no generated proxies) — sample works around via registration ordering.
2. UoW middleware requires MVC `ActionDescriptor` — Minimal APIs silently skip the unit of work; controllers are the golden path.
3. Options type-lists (Template engines/contributors, Settings/Permissions providers) resolve **concrete types** from DI that the `AddXxx` methods never register.
4. `Localization.Json` resolves `IFileProvider` while VFS registers `IVirtualFileProvider` — needs a bridge registration.
5. Single-file template content is unreachable with `isInlineLocalized: false` (the fallback chain never queries the culture-independent content) — the removed email module had this latent bug too.
6. Scriban engine requires MS `IStringLocalizerFactory` (framework localization registers its own) and throws on templates without a `LocalizationResource` type.
7. `LocalChannelEventBus` consumer loop dies silently on the first handler exception (unobserved task).
8. `DefaultErrorConverter` masks every non-`UserFriendlyException` (including `AuthorizationException`/`SkywalkerValidationException` codes) as `InternalServerError`; `ExceptionFilter` ignores `x-wrap-result: false` and never sets `unAuthorizedRequest`.

## Verification

- Full solution build: 0 warnings / 0 errors.
- Smoke: **20/20 assertions pass** locally (`--smoke`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
