### PR TITLE
fix: interception skips constructed generics; local event bus survives handler failures (#308, #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+- `AddInterceptedServices()` 不再对闭合泛型实现的注册抛启动异常：source generator 按编译期声明类型生成代理，运行时构造的泛型实现（如 EF SG 生成注册的 `EntityFrameworkCoreDomainService<TEntity, TKey>`）不可能有生成代理，现跳过并保留原注册——修复"任何同时使用 `AddSkywalkerDbContext` + `AddInterceptedServices` 的应用无法启动"。DynamicProxy SG 同时对泛型实现类设防（此前开放泛型候选会拖垮编译器 csc 崩溃）（#308）。
+- `LocalChannelEventBus` 消费循环不再因单个处理器异常而静默死亡：处理器失败按事件记录 `ILogger` 错误并继续消费；循环意外终止记 Critical 日志。此前首个抛异常的处理器会杀死消费循环，之后所有事件被静默丢弃（#309）。
 - `AddSkywalkerDbContextPool<TDbContext>` 修复池化 DbContext 全链路不可用：补上 `IRepository<,>` / `IDomainService<,>` 默认注册（generated-first + 反射 fallback，与非池化对齐）；移除抢占 `DbContextOptions<TDbContext>` 的错误注册，调用方的 options 配置不再被静默忽略；`IValueGeneratorSelector` 替换前移到池的 options 构建阶段，`OnConfiguring` 检测到已替换时跳过，池化上下文不再抛出 "OnConfiguring cannot be used to modify DbContextOptions"（#299）。
 
 ### Changed — BREAKING (Messaging & Transport 独立为 Vertex 项目)

--- a/src/Skywalker.EventBus.Local/PublicAPI.Unshipped.txt
+++ b/src/Skywalker.EventBus.Local/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*Skywalker.EventBus.Local.LocalChannelEventBus.LocalChannelEventBus(Skywalker.EventBus.Abstractions.IEventHandlerFactory! handlerFactory, Skywalker.EventBus.Abstractions.IEventHandlerInvoker! handlerInvoker, Microsoft.Extensions.Options.IOptions<Skywalker.EventBus.Local.LocalEventBusOptions!>! options) -> void
+Skywalker.EventBus.Local.LocalChannelEventBus.LocalChannelEventBus(Skywalker.EventBus.Abstractions.IEventHandlerFactory! handlerFactory, Skywalker.EventBus.Abstractions.IEventHandlerInvoker! handlerInvoker, Microsoft.Extensions.Options.IOptions<Skywalker.EventBus.Local.LocalEventBusOptions!>! options, Microsoft.Extensions.Logging.ILogger<Skywalker.EventBus.Local.LocalChannelEventBus!>? logger = null) -> void

--- a/src/Skywalker.EventBus.Local/Skywalker.EventBus.Local.csproj
+++ b/src/Skywalker.EventBus.Local/Skywalker.EventBus.Local.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace></RootNamespace>
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
@@ -15,4 +16,6 @@
   </ItemGroup>
 
 </Project>
+
+
 

--- a/src/Skywalker.EventBus.Local/Skywalker/EventBus/Local/LocalChannelEventBus.cs
+++ b/src/Skywalker.EventBus.Local/Skywalker/EventBus/Local/LocalChannelEventBus.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Skywalker.EventBus.Abstractions;
 
@@ -12,6 +14,7 @@ public class LocalChannelEventBus : EventBusBase, ILocalEventBus, IAsyncDisposab
 {
     private readonly IEventHandlerFactory _handlerFactory;
     private readonly IEventHandlerInvoker _handlerInvoker;
+    private readonly ILogger<LocalChannelEventBus> _logger;
     private readonly ConcurrentDictionary<Type, List<Type>> _handlerTypes;
     private readonly Channel<EventMessage> _channel;
     private readonly Task _processingTask;
@@ -21,10 +24,12 @@ public class LocalChannelEventBus : EventBusBase, ILocalEventBus, IAsyncDisposab
     public LocalChannelEventBus(
         IEventHandlerFactory handlerFactory,
         IEventHandlerInvoker handlerInvoker,
-        IOptions<LocalEventBusOptions> options)
+        IOptions<LocalEventBusOptions> options,
+        ILogger<LocalChannelEventBus>? logger = null)
     {
         _handlerFactory = handlerFactory;
         _handlerInvoker = handlerInvoker;
+        _logger = logger ?? NullLogger<LocalChannelEventBus>.Instance;
         _handlerTypes = new ConcurrentDictionary<Type, List<Type>>();
         _cts = new CancellationTokenSource();
 
@@ -121,6 +126,13 @@ public class LocalChannelEventBus : EventBusBase, ILocalEventBus, IAsyncDisposab
                         // Service provider was disposed during shutdown, ignore
                         break;
                     }
+                    catch (Exception exception)
+                    {
+                        // 单个处理器失败不能杀死消费循环，否则后续所有事件被静默丢弃（#309）
+                        _logger.LogError(exception,
+                            "Event handler {HandlerType} failed for event {EventType}.",
+                            handlerType.FullName, message.EventType.FullName);
+                    }
                 }
             }
         }
@@ -131,6 +143,11 @@ public class LocalChannelEventBus : EventBusBase, ILocalEventBus, IAsyncDisposab
         catch (ObjectDisposedException)
         {
             // Service provider was disposed during shutdown, ignore
+        }
+        catch (Exception exception)
+        {
+            // 兜底：消费循环意外终止必须可观测（#309）
+            _logger.LogCritical(exception, "Local event bus processing loop terminated unexpectedly.");
         }
     }
 

--- a/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
+++ b/src/Skywalker.Extensions.DynamicProxies.SourceGenerators/DynamicProxyRegistrationGenerator.cs
@@ -45,6 +45,12 @@ public sealed class DynamicProxyRegistrationGenerator : IIncrementalGenerator
             return null;
         }
 
+        // 泛型实现类不支持静态代理（代理按封闭类型生成；开放泛型会产出无效代码甚至拖垮编译器），跳过（#308）
+        if (implementation.IsGenericType)
+        {
+            return null;
+        }
+
         var proxies = ImmutableArray.CreateBuilder<ProxyModel>();
         foreach (var serviceInterface in implementation.AllInterfaces
             .Where(static type => type.OriginalDefinition.ToDisplayString() != InterceptableMetadataName)

--- a/src/Skywalker.Extensions.DynamicProxies/Microsoft/Extensions/DependencyInjection/DynamicProxyServiceCollectionExtensions.cs
+++ b/src/Skywalker.Extensions.DynamicProxies/Microsoft/Extensions/DependencyInjection/DynamicProxyServiceCollectionExtensions.cs
@@ -61,6 +61,14 @@ public static class DynamicProxyServiceCollectionExtensions
                 continue;
             }
 
+            // 跳过闭合泛型实现：source generator 按编译期声明的类型生成代理，
+            // 运行时构造的泛型实现（如 EF SG 生成注册的 EntityFrameworkCoreDomainService<TEntity, TKey>）
+            // 不可能拥有生成代理，保持原注册不代理（#308）。
+            if (implType.IsConstructedGenericType)
+            {
+                continue;
+            }
+
             var serviceType = descriptor.ServiceType;
             var lifetime = descriptor.Lifetime;
 

--- a/tests/Skywalker.EventBus.Tests/LocalChannelEventBusResilienceTests.cs
+++ b/tests/Skywalker.EventBus.Tests/LocalChannelEventBusResilienceTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.EventBus.Abstractions;
+using Skywalker.EventBus.Local;
+
+namespace Skywalker.EventBus.Tests;
+
+/// <summary>
+/// #309：单个处理器抛异常不能杀死消费循环，后续事件必须继续投递。
+/// </summary>
+public class LocalChannelEventBusResilienceTests
+{
+    public class ResilienceEvent
+    {
+        public string Message { get; set; } = string.Empty;
+    }
+
+    public class ThrowingEventHandler : IEventHandler<ResilienceEvent>
+    {
+        public Task HandleEventAsync(ResilienceEvent eventData)
+        {
+            throw new InvalidOperationException("poisoned handler");
+        }
+    }
+
+    public class RecordingEventHandler : IEventHandler<ResilienceEvent>
+    {
+        public static List<ResilienceEvent> ReceivedEvents { get; } = [];
+
+        public Task HandleEventAsync(ResilienceEvent eventData)
+        {
+            ReceivedEvents.Add(eventData);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ProcessingLoop_SurvivesHandlerFailure_AndKeepsDispatchingSubsequentEvents()
+    {
+        // Arrange：同一事件先经过抛异常的处理器，再经过记录处理器
+        var services = new ServiceCollection();
+        services.AddEventBusLocal(options =>
+        {
+            options.AddEventHandler<ThrowingEventHandler>();
+            options.AddEventHandler<RecordingEventHandler>();
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var eventBus = provider.GetRequiredService<ILocalEventBus>();
+        RecordingEventHandler.ReceivedEvents.Clear();
+
+        // Act：第一条事件毒化 ThrowingEventHandler；第二条事件验证循环仍存活
+        await eventBus.PublishAsync(new ResilienceEvent { Message = "first" });
+        await eventBus.PublishAsync(new ResilienceEvent { Message = "second" });
+
+        for (var i = 0; i < 20 && RecordingEventHandler.ReceivedEvents.Count < 2; i++)
+        {
+            await Task.Delay(100);
+        }
+
+        // Assert：两条事件都送达了记录处理器（抛异常的处理器没有杀死循环）
+        Assert.Equal(2, RecordingEventHandler.ReceivedEvents.Count);
+        Assert.Equal("first", RecordingEventHandler.ReceivedEvents[0].Message);
+        Assert.Equal("second", RecordingEventHandler.ReceivedEvents[1].Message);
+    }
+}

--- a/tests/Skywalker.Extensions.DynamicProxies.Tests/ConstructedGenericInterceptionTests.cs
+++ b/tests/Skywalker.Extensions.DynamicProxies.Tests/ConstructedGenericInterceptionTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using Skywalker.Extensions.DynamicProxies;
+
+namespace Skywalker.Extensions.DynamicProxies.Tests;
+
+/// <summary>
+/// #308：闭合泛型实现（如 EF SG 生成注册的 EntityFrameworkCoreDomainService&lt;TEntity, TKey&gt;）
+/// 不可能拥有 source-generated 代理；AddInterceptedServices 必须跳过而非抛出启动异常。
+/// </summary>
+public sealed class ConstructedGenericInterceptionTests
+{
+    public interface IGenericDomainService<TEntity> : IInterceptable
+    {
+        Task<TEntity?> FindAsync();
+    }
+
+    public class GenericDomainService<TEntity> : IGenericDomainService<TEntity>
+    {
+        public Task<TEntity?> FindAsync() => Task.FromResult(default(TEntity));
+    }
+
+    [Fact]
+    public void AddInterceptedServices_SkipsConstructedGenericImplementations_WithoutThrowing()
+    {
+        var services = new ServiceCollection();
+        // 模拟 EF SG 生成的闭合泛型注册：IDomainService<Entity> -> EntityFrameworkCoreDomainService<Entity, Key>
+        services.AddTransient(typeof(IGenericDomainService<string>), typeof(GenericDomainService<string>));
+
+        // 修复前此调用抛 InvalidOperationException（no source-generated DynamicProxy metadata）
+        var exception = Record.Exception(() => services.AddInterceptedServices());
+
+        Assert.Null(exception);
+
+        using var provider = services.BuildServiceProvider();
+        var service = provider.GetRequiredService<IGenericDomainService<string>>();
+
+        // 原注册保持不代理
+        Assert.IsType<GenericDomainService<string>>(service);
+    }
+}


### PR DESCRIPTION
Fixes #308, fixes #309 — the two P1s surfaced by the full-stack website sample (#307).

**#308** — \AddInterceptedServices()\ threw at startup for EF SG generated \IDomainService<,>\ closed-generic registrations (breaking any app combining \AddSkywalkerDbContext\ + \AddInterceptedServices\). Constructed-generic implementations can never have source-generated proxies (the SG works on compile-time declared types), so the scan now skips them and keeps the original registration. The DynamicProxy SG also guards against generic implementation classes — an open-generic candidate previously crashed csc itself (MSB6006).

**#309** — \LocalChannelEventBus\'s consumer loop died silently on the first handler exception, dropping all subsequent events with no trace. Handler failures are now logged per event (\ILogger<LocalChannelEventBus>\, optional ctor param, PublicAPI updated) and the loop keeps consuming; an unexpected loop termination logs Critical.

Tests: \ConstructedGenericInterceptionTests\ (would previously throw / crash the compiler), \LocalChannelEventBusResilienceTests\ (poisoned handler + subsequent event still delivered). DynamicProxies 15/15, EventBus 28/28, SG snapshots 110/110, full solution build clean, website sample smoke 20/20.

